### PR TITLE
Processor: `InitializeHolderRewards`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2620,6 +2620,7 @@ dependencies = [
  "spl-token-2022 3.0.2",
  "spl-transfer-hook-interface 0.6.3",
  "spl-type-length-value 0.4.3",
+ "test-case",
 ]
 
 [[package]]

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -23,6 +23,7 @@ solana-program-test = "1.18.14"
 solana-sdk = "1.18.14"
 spl-pod = "0.2.2"
 spl-type-length-value = "0.4.3"
+test-case = "3.3.1"
 
 [features]
 bpf-entrypoint = []

--- a/program/src/error.rs
+++ b/program/src/error.rs
@@ -17,4 +17,10 @@ pub enum PaladinRewardsError {
     /// Incorrect extra metas address.
     #[error("Incorrect extra metas address")]
     IncorrectExtraMetasAddress,
+    /// Incorrect holder rewards address.
+    #[error("Incorrect holder rewards address")]
+    IncorrectHolderRewardsAddress,
+    /// Token account mint mismatch.
+    #[error("Token account mint mismatch")]
+    TokenAccountMintMismatch,
 }

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -301,10 +301,10 @@ fn process_initialize_holder_rewards(
     let unharvested_rewards = {
         let rent = <Rent as Sysvar>::get()?;
         let rent_exempt_lamports = rent.minimum_balance(std::mem::size_of::<HolderRewardsPool>());
-        let active_rewards = holder_rewards_pool_info
+        let available_rewards = holder_rewards_pool_info
             .lamports()
             .saturating_sub(rent_exempt_lamports);
-        calculate_reward_share(token_supply, token_account_balance, active_rewards)?
+        calculate_reward_share(token_supply, token_account_balance, available_rewards)?
     };
 
     // Initialize the holder rewards account.

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -6,8 +6,9 @@ use {
         extra_metas::get_extra_account_metas,
         instruction::PaladinRewardsInstruction,
         state::{
-            collect_holder_rewards_pool_signer_seeds,
-            get_holder_rewards_pool_address_and_bump_seed, HolderRewardsPool,
+            collect_holder_rewards_pool_signer_seeds, collect_holder_rewards_signer_seeds,
+            get_holder_rewards_address_and_bump_seed, get_holder_rewards_pool_address,
+            get_holder_rewards_pool_address_and_bump_seed, HolderRewards, HolderRewardsPool,
         },
     },
     solana_program::{
@@ -23,13 +24,28 @@ use {
     spl_tlv_account_resolution::state::ExtraAccountMetaList,
     spl_token_2022::{
         extension::{transfer_hook::TransferHook, BaseStateWithExtensions, StateWithExtensions},
-        state::Mint,
+        state::{Account, Mint},
     },
     spl_transfer_hook_interface::{
         collect_extra_account_metas_signer_seeds, get_extra_account_metas_address_and_bump_seed,
         instruction::{ExecuteInstruction, TransferHookInstruction},
     },
 };
+
+fn calculate_reward_share(
+    token_supply: u64,
+    token_account_balance: u64,
+    total_rewards: u64,
+) -> Result<u64, ProgramError> {
+    if token_supply == 0 {
+        return Ok(0);
+    }
+    // (token_amount / total_token_supply) * pool_rewards
+    token_account_balance
+        .checked_div(token_supply)
+        .and_then(|share| share.checked_mul(total_rewards))
+        .ok_or(ProgramError::ArithmeticOverflow)
+}
 
 /// Processes an
 /// [InitializeHolderRewardsPool](enum.PaladinRewardsInstruction.html)
@@ -210,9 +226,109 @@ fn process_distribute_rewards(
 /// [InitializeHolderRewards](enum.PaladinRewardsInstruction.html)
 /// instruction.
 fn process_initialize_holder_rewards(
-    _program_id: &Pubkey,
-    _accounts: &[AccountInfo],
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
 ) -> ProgramResult {
+    let accounts_iter = &mut accounts.iter();
+
+    let holder_rewards_pool_info = next_account_info(accounts_iter)?;
+    let holder_rewards_info = next_account_info(accounts_iter)?;
+    let token_account_info = next_account_info(accounts_iter)?;
+    let mint_info = next_account_info(accounts_iter)?;
+    let _system_program = next_account_info(accounts_iter)?;
+
+    let token_supply = {
+        let mint_data = mint_info.try_borrow_data()?;
+        let mint = StateWithExtensions::<Mint>::unpack(&mint_data)?;
+        mint.base.supply
+    };
+
+    let token_account_balance = {
+        let token_account_data = token_account_info.try_borrow_data()?;
+        let token_account = StateWithExtensions::<Account>::unpack(&token_account_data)?;
+
+        // Ensure the provided token account is for the mint.
+        if !token_account.base.mint.eq(mint_info.key) {
+            return Err(PaladinRewardsError::TokenAccountMintMismatch.into());
+        }
+
+        token_account.base.amount
+    };
+
+    let total_rewards = {
+        // Ensure the holder rewards pool is owned by the Paladin Rewards
+        // program.
+        if !holder_rewards_pool_info.owner.eq(&crate::id()) {
+            return Err(ProgramError::InvalidAccountOwner);
+        }
+
+        // Ensure the provided holder rewards pool address is the correct
+        // address derived from the mint.
+        if !holder_rewards_pool_info
+            .key
+            .eq(&get_holder_rewards_pool_address(mint_info.key))
+        {
+            return Err(PaladinRewardsError::IncorrectHolderRewardsPoolAddress.into());
+        }
+
+        let holder_rewards_pool_data = holder_rewards_pool_info.try_borrow_data()?;
+        let holder_rewards_pool_state =
+            bytemuck::try_from_bytes::<HolderRewardsPool>(&holder_rewards_pool_data)
+                .map_err(|_| ProgramError::InvalidAccountData)?;
+
+        holder_rewards_pool_state.total_rewards
+    };
+
+    // Calculate unharvested rewards for the token account.
+    // Since the holder rewards account is being initialized, the
+    // `unharvested_rewards` is calculated from the current `total_rewards` in
+    // the pool.
+    let unharvested_rewards =
+        calculate_reward_share(token_supply, token_account_balance, total_rewards)?;
+
+    // Initialize the holder rewards account.
+    {
+        let (holder_rewards_address, bump_seed) =
+            get_holder_rewards_address_and_bump_seed(token_account_info.key);
+        let bump_seed = [bump_seed];
+        let holder_rewards_signer_seeds =
+            collect_holder_rewards_signer_seeds(token_account_info.key, &bump_seed);
+
+        // Ensure the provided holder rewards address is the correct address
+        // derived from the token account.
+        if !holder_rewards_info.key.eq(&holder_rewards_address) {
+            return Err(PaladinRewardsError::IncorrectHolderRewardsAddress.into());
+        }
+
+        // Ensure the holder rewards account has not already been initialized.
+        if holder_rewards_info.data.borrow().len() != 0 {
+            return Err(ProgramError::AccountAlreadyInitialized);
+        }
+
+        // Allocate & assign.
+        invoke_signed(
+            &system_instruction::allocate(
+                &holder_rewards_address,
+                std::mem::size_of::<HolderRewards>() as u64,
+            ),
+            &[holder_rewards_info.clone()],
+            &[&holder_rewards_signer_seeds],
+        )?;
+        invoke_signed(
+            &system_instruction::assign(&holder_rewards_address, program_id),
+            &[holder_rewards_info.clone()],
+            &[&holder_rewards_signer_seeds],
+        )?;
+
+        // Write the data.
+        let mut data = holder_rewards_info.try_borrow_mut_data()?;
+        *bytemuck::try_from_bytes_mut(&mut data).map_err(|_| ProgramError::InvalidAccountData)? =
+            HolderRewards {
+                last_seen_total_rewards: total_rewards,
+                unharvested_rewards,
+            };
+    }
+
     Ok(())
 }
 

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -258,7 +258,7 @@ fn process_initialize_holder_rewards(
     let total_rewards = {
         // Ensure the holder rewards pool is owned by the Paladin Rewards
         // program.
-        if !holder_rewards_pool_info.owner.eq(&crate::id()) {
+        if !holder_rewards_pool_info.owner.eq(program_id) {
             return Err(ProgramError::InvalidAccountOwner);
         }
 

--- a/program/src/state.rs
+++ b/program/src/state.rs
@@ -32,7 +32,6 @@ pub(crate) fn collect_holder_rewards_seeds(token_account_address: &Pubkey) -> [&
     [SEED_PREFIX_HOLDER_REWARDS, token_account_address.as_ref()]
 }
 
-#[allow(unused)] // For now.
 pub(crate) fn collect_holder_rewards_signer_seeds<'a>(
     token_account_address: &'a Pubkey,
     bump_seed: &'a [u8],

--- a/program/tests/distribute_rewards.rs
+++ b/program/tests/distribute_rewards.rs
@@ -144,7 +144,7 @@ async fn success() {
 
     let mut context = setup().start_with_context().await;
     setup_system_account(&mut context, &payer.pubkey(), amount).await;
-    setup_holder_rewards_pool_account(&mut context, &holder_rewards_pool, 0).await;
+    setup_holder_rewards_pool_account(&mut context, &holder_rewards_pool, 0, 0).await;
 
     // For checks later.
     let payer_beginning_lamports = context

--- a/program/tests/initialize_holder_rewards.rs
+++ b/program/tests/initialize_holder_rewards.rs
@@ -1,0 +1,459 @@
+#![cfg(feature = "test-sbf")]
+
+mod setup;
+
+use {
+    paladin_rewards_program::{
+        error::PaladinRewardsError,
+        instruction::initialize_holder_rewards,
+        state::{get_holder_rewards_address, get_holder_rewards_pool_address, HolderRewards},
+    },
+    setup::{setup, setup_holder_rewards_pool_account, setup_mint, setup_token_account},
+    solana_program_test::*,
+    solana_sdk::{
+        account::{Account, AccountSharedData},
+        instruction::InstructionError,
+        pubkey::Pubkey,
+        signer::Signer,
+        system_program,
+        transaction::{Transaction, TransactionError},
+    },
+    spl_associated_token_account::get_associated_token_address,
+    test_case::test_case,
+};
+
+#[tokio::test]
+async fn fail_mint_invalid_data() {
+    let owner = Pubkey::new_unique();
+    let mint = Pubkey::new_unique();
+
+    let token_account = get_associated_token_address(&owner, &mint);
+    let holder_rewards = get_holder_rewards_address(&token_account);
+    let holder_rewards_pool = get_holder_rewards_pool_address(&mint);
+
+    let mut context = setup().start_with_context().await;
+
+    // Set up a mint with invalid data.
+    {
+        context.set_account(
+            &mint,
+            &AccountSharedData::new_data(100_000_000, &vec![5; 165], &spl_token_2022::id())
+                .unwrap(),
+        );
+    }
+
+    let instruction =
+        initialize_holder_rewards(&holder_rewards_pool, &holder_rewards, &token_account, &mint);
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[instruction],
+        Some(&context.payer.pubkey()),
+        &[&context.payer],
+        context.last_blockhash,
+    );
+
+    let err = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
+        .unwrap();
+
+    assert_eq!(
+        err,
+        TransactionError::InstructionError(0, InstructionError::InvalidAccountData)
+    );
+}
+
+#[tokio::test]
+async fn fail_token_account_invalid_data() {
+    let owner = Pubkey::new_unique();
+    let mint = Pubkey::new_unique();
+
+    let token_account = get_associated_token_address(&owner, &mint);
+    let holder_rewards = get_holder_rewards_address(&token_account);
+    let holder_rewards_pool = get_holder_rewards_pool_address(&mint);
+
+    let mut context = setup().start_with_context().await;
+    setup_mint(&mut context, &mint, &Pubkey::new_unique(), 0).await;
+
+    // Set up a token account with invalid data.
+    {
+        context.set_account(
+            &token_account,
+            &AccountSharedData::new_data(100_000_000, &vec![5; 165], &spl_token_2022::id())
+                .unwrap(),
+        );
+    }
+
+    let instruction =
+        initialize_holder_rewards(&holder_rewards_pool, &holder_rewards, &token_account, &mint);
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[instruction],
+        Some(&context.payer.pubkey()),
+        &[&context.payer],
+        context.last_blockhash,
+    );
+
+    let err = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
+        .unwrap();
+
+    assert_eq!(
+        err,
+        TransactionError::InstructionError(0, InstructionError::InvalidAccountData)
+    );
+}
+
+#[tokio::test]
+async fn fail_token_account_mint_mismatch() {
+    let owner = Pubkey::new_unique();
+    let mint = Pubkey::new_unique();
+
+    let token_account = get_associated_token_address(&owner, &mint);
+    let holder_rewards = get_holder_rewards_address(&token_account);
+    let holder_rewards_pool = get_holder_rewards_pool_address(&mint);
+
+    let mut context = setup().start_with_context().await;
+    setup_token_account(
+        &mut context,
+        &token_account,
+        &owner,
+        &Pubkey::new_unique(), // Incorrect mint.
+        0,
+    )
+    .await;
+    setup_mint(&mut context, &mint, &Pubkey::new_unique(), 0).await;
+
+    let instruction =
+        initialize_holder_rewards(&holder_rewards_pool, &holder_rewards, &token_account, &mint);
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[instruction],
+        Some(&context.payer.pubkey()),
+        &[&context.payer],
+        context.last_blockhash,
+    );
+
+    let err = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
+        .unwrap();
+
+    assert_eq!(
+        err,
+        TransactionError::InstructionError(
+            0,
+            InstructionError::Custom(PaladinRewardsError::TokenAccountMintMismatch as u32)
+        )
+    );
+}
+
+#[tokio::test]
+async fn fail_holder_rewards_pool_incorrect_owner() {
+    let owner = Pubkey::new_unique();
+    let mint = Pubkey::new_unique();
+
+    let token_account = get_associated_token_address(&owner, &mint);
+    let holder_rewards = get_holder_rewards_address(&token_account);
+    let holder_rewards_pool = get_holder_rewards_pool_address(&mint);
+
+    let mut context = setup().start_with_context().await;
+    setup_token_account(&mut context, &token_account, &owner, &mint, 0).await;
+    setup_mint(&mut context, &mint, &Pubkey::new_unique(), 0).await;
+
+    // Set up a holder rewards pool account with incorrect owner.
+    {
+        context.set_account(
+            &holder_rewards_pool,
+            &AccountSharedData::new_data(100_000_000, &vec![5; 165], &Pubkey::new_unique())
+                .unwrap(),
+        );
+    }
+
+    let instruction =
+        initialize_holder_rewards(&holder_rewards_pool, &holder_rewards, &token_account, &mint);
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[instruction],
+        Some(&context.payer.pubkey()),
+        &[&context.payer],
+        context.last_blockhash,
+    );
+
+    let err = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
+        .unwrap();
+
+    assert_eq!(
+        err,
+        TransactionError::InstructionError(0, InstructionError::InvalidAccountOwner)
+    );
+}
+
+#[tokio::test]
+async fn fail_holder_rewards_pool_incorrect_address() {
+    let owner = Pubkey::new_unique();
+    let mint = Pubkey::new_unique();
+
+    let token_account = get_associated_token_address(&owner, &mint);
+    let holder_rewards = get_holder_rewards_address(&token_account);
+    let holder_rewards_pool = Pubkey::new_unique(); // Incorrect holder rewards pool address.
+
+    let mut context = setup().start_with_context().await;
+    setup_holder_rewards_pool_account(&mut context, &holder_rewards_pool, 0).await;
+    setup_token_account(&mut context, &token_account, &owner, &mint, 0).await;
+    setup_mint(&mut context, &mint, &Pubkey::new_unique(), 0).await;
+
+    let instruction =
+        initialize_holder_rewards(&holder_rewards_pool, &holder_rewards, &token_account, &mint);
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[instruction],
+        Some(&context.payer.pubkey()),
+        &[&context.payer],
+        context.last_blockhash,
+    );
+
+    let err = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
+        .unwrap();
+
+    assert_eq!(
+        err,
+        TransactionError::InstructionError(
+            0,
+            InstructionError::Custom(PaladinRewardsError::IncorrectHolderRewardsPoolAddress as u32)
+        )
+    );
+}
+
+#[tokio::test]
+async fn fail_holder_rewards_pool_invalid_data() {
+    let owner = Pubkey::new_unique();
+    let mint = Pubkey::new_unique();
+
+    let token_account = get_associated_token_address(&owner, &mint);
+    let holder_rewards = get_holder_rewards_address(&token_account);
+    let holder_rewards_pool = get_holder_rewards_pool_address(&mint);
+
+    let mut context = setup().start_with_context().await;
+    setup_token_account(&mut context, &token_account, &owner, &mint, 0).await;
+    setup_mint(&mut context, &mint, &Pubkey::new_unique(), 0).await;
+
+    // Set up a holder rewards pool account with invalid data.
+    {
+        context.set_account(
+            &holder_rewards_pool,
+            &AccountSharedData::new_data(100_000_000, &vec![5; 165], &spl_token_2022::id())
+                .unwrap(),
+        );
+    }
+
+    let instruction =
+        initialize_holder_rewards(&holder_rewards_pool, &holder_rewards, &token_account, &mint);
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[instruction],
+        Some(&context.payer.pubkey()),
+        &[&context.payer],
+        context.last_blockhash,
+    );
+
+    let err = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
+        .unwrap();
+
+    assert_eq!(
+        err,
+        TransactionError::InstructionError(0, InstructionError::InvalidAccountOwner)
+    );
+}
+
+#[tokio::test]
+async fn fail_holder_rewards_incorrect_address() {
+    let owner = Pubkey::new_unique();
+    let mint = Pubkey::new_unique();
+
+    let token_account = get_associated_token_address(&owner, &mint);
+    let holder_rewards = Pubkey::new_unique(); // Incorrect holder reward address.
+    let holder_rewards_pool = get_holder_rewards_pool_address(&mint);
+
+    let mut context = setup().start_with_context().await;
+    setup_holder_rewards_pool_account(&mut context, &holder_rewards_pool, 0).await;
+    setup_token_account(&mut context, &token_account, &owner, &mint, 0).await;
+    setup_mint(&mut context, &mint, &Pubkey::new_unique(), 0).await;
+
+    let instruction =
+        initialize_holder_rewards(&holder_rewards_pool, &holder_rewards, &token_account, &mint);
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[instruction],
+        Some(&context.payer.pubkey()),
+        &[&context.payer],
+        context.last_blockhash,
+    );
+
+    let err = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
+        .unwrap();
+
+    assert_eq!(
+        err,
+        TransactionError::InstructionError(
+            0,
+            InstructionError::Custom(PaladinRewardsError::IncorrectHolderRewardsAddress as u32)
+        )
+    );
+}
+
+#[tokio::test]
+async fn fail_holder_rewards_account_initialized() {
+    let owner = Pubkey::new_unique();
+    let mint = Pubkey::new_unique();
+
+    let token_account = get_associated_token_address(&owner, &mint);
+    let holder_rewards = get_holder_rewards_address(&token_account);
+    let holder_rewards_pool = get_holder_rewards_pool_address(&mint);
+
+    let mut context = setup().start_with_context().await;
+    setup_holder_rewards_pool_account(&mut context, &holder_rewards_pool, 0).await;
+    setup_token_account(&mut context, &token_account, &owner, &mint, 0).await;
+    setup_mint(&mut context, &mint, &Pubkey::new_unique(), 0).await;
+
+    // Set up an already (arbitrarily) initialized holder rewards account.
+    {
+        context.set_account(
+            &holder_rewards,
+            &AccountSharedData::from(Account {
+                lamports: 1_000_000_000,
+                data: vec![2; 45],
+                owner: paladin_rewards_program::id(),
+                ..Account::default()
+            }),
+        );
+    }
+
+    let instruction =
+        initialize_holder_rewards(&holder_rewards_pool, &holder_rewards, &token_account, &mint);
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[instruction],
+        Some(&context.payer.pubkey()),
+        &[&context.payer],
+        context.last_blockhash,
+    );
+
+    let err = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
+        .unwrap();
+
+    assert_eq!(
+        err,
+        TransactionError::InstructionError(0, InstructionError::AccountAlreadyInitialized)
+    );
+}
+
+#[allow(clippy::arithmetic_side_effects)]
+#[test_case(0, 0, 0)]
+#[test_case(10, 5, 10)]
+#[test_case(500_000, 1_000, 1_000)]
+#[test_case(500_000, 1_000, 50_000_000)]
+#[test_case(500_000, 1_000, 40_000_000_000)]
+#[test_case(100_000_000, 10_000_000, 1_000)]
+#[test_case(100_000_000, 10_000_000, 50_000_000)]
+#[test_case(100_000_000, 10_000_000, 40_000_000_000)]
+#[test_case(20_000_000_000, 50_000_000, 1_000)]
+#[test_case(20_000_000_000, 50_000_000, 50_000_000)]
+#[test_case(20_000_000_000, 50_000_000, 40_000_000_000)]
+#[tokio::test]
+async fn success(token_supply: u64, token_account_balance: u64, total_rewards: u64) {
+    let owner = Pubkey::new_unique();
+    let mint = Pubkey::new_unique();
+
+    let token_account = get_associated_token_address(&owner, &mint);
+    let holder_rewards = get_holder_rewards_address(&token_account);
+    let holder_rewards_pool = get_holder_rewards_pool_address(&mint);
+
+    let mut context = setup().start_with_context().await;
+    setup_holder_rewards_pool_account(&mut context, &holder_rewards_pool, total_rewards).await;
+    setup_token_account(
+        &mut context,
+        &token_account,
+        &owner,
+        &mint,
+        token_account_balance,
+    )
+    .await;
+    setup_mint(&mut context, &mint, &Pubkey::new_unique(), token_supply).await;
+
+    // Fund the holder rewards account.
+    {
+        let rent = context.banks_client.get_rent().await.unwrap();
+        let lamports = rent.minimum_balance(std::mem::size_of::<HolderRewards>());
+        context.set_account(
+            &holder_rewards,
+            &AccountSharedData::new(lamports, 0, &system_program::id()),
+        );
+    }
+
+    let instruction =
+        initialize_holder_rewards(&holder_rewards_pool, &holder_rewards, &token_account, &mint);
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[instruction],
+        Some(&context.payer.pubkey()),
+        &[&context.payer],
+        context.last_blockhash,
+    );
+
+    context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap();
+
+    let expected_unharvested_rewards = {
+        if token_supply == 0 {
+            0
+        } else {
+            (token_account_balance / token_supply) * total_rewards
+        }
+    };
+
+    // Check the holder rewards account.
+    let holder_rewards_account = context
+        .banks_client
+        .get_account(holder_rewards)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        bytemuck::from_bytes::<HolderRewards>(&holder_rewards_account.data),
+        &HolderRewards {
+            last_seen_total_rewards: total_rewards,
+            unharvested_rewards: expected_unharvested_rewards,
+        },
+    );
+}

--- a/program/tests/initialize_holder_rewards.rs
+++ b/program/tests/initialize_holder_rewards.rs
@@ -172,8 +172,7 @@ async fn fail_holder_rewards_pool_incorrect_owner() {
     {
         context.set_account(
             &holder_rewards_pool,
-            &AccountSharedData::new_data(100_000_000, &vec![5; 165], &Pubkey::new_unique())
-                .unwrap(),
+            &AccountSharedData::new_data(100_000_000, &vec![5; 8], &Pubkey::new_unique()).unwrap(),
         );
     }
 
@@ -257,8 +256,12 @@ async fn fail_holder_rewards_pool_invalid_data() {
     {
         context.set_account(
             &holder_rewards_pool,
-            &AccountSharedData::new_data(100_000_000, &vec![5; 165], &spl_token_2022::id())
-                .unwrap(),
+            &AccountSharedData::new_data(
+                100_000_000,
+                &vec![5; 165],
+                &paladin_rewards_program::id(),
+            )
+            .unwrap(),
         );
     }
 
@@ -281,7 +284,7 @@ async fn fail_holder_rewards_pool_invalid_data() {
 
     assert_eq!(
         err,
-        TransactionError::InstructionError(0, InstructionError::InvalidAccountOwner)
+        TransactionError::InstructionError(0, InstructionError::InvalidAccountData)
     );
 }
 
@@ -345,7 +348,7 @@ async fn fail_holder_rewards_account_initialized() {
             &holder_rewards,
             &AccountSharedData::from(Account {
                 lamports: 1_000_000_000,
-                data: vec![2; 45],
+                data: vec![2; 16],
                 owner: paladin_rewards_program::id(),
                 ..Account::default()
             }),

--- a/program/tests/initialize_holder_rewards.rs
+++ b/program/tests/initialize_holder_rewards.rs
@@ -391,7 +391,7 @@ async fn fail_holder_rewards_account_initialized() {
 #[test_case(20_000_000_000, 50_000_000, 50_000_000)]
 #[test_case(20_000_000_000, 50_000_000, 40_000_000_000)]
 #[tokio::test]
-async fn success(token_supply: u64, token_account_balance: u64, active_rewards: u64) {
+async fn success(token_supply: u64, token_account_balance: u64, available_rewards: u64) {
     let owner = Pubkey::new_unique();
     let mint = Pubkey::new_unique();
 
@@ -399,13 +399,13 @@ async fn success(token_supply: u64, token_account_balance: u64, active_rewards: 
     let holder_rewards = get_holder_rewards_address(&token_account);
     let holder_rewards_pool = get_holder_rewards_pool_address(&mint);
 
-    let expected_last_seen_total_rewards = active_rewards + 500_000; // Arbitrary.
+    let expected_last_seen_total_rewards = available_rewards + 500_000; // Arbitrary.
 
     let mut context = setup().start_with_context().await;
     setup_holder_rewards_pool_account(
         &mut context,
         &holder_rewards_pool,
-        active_rewards,
+        available_rewards,
         expected_last_seen_total_rewards,
     )
     .await;
@@ -449,7 +449,7 @@ async fn success(token_supply: u64, token_account_balance: u64, active_rewards: 
         if token_supply == 0 {
             0
         } else {
-            ((token_account_balance as u128) * (active_rewards as u128) / (token_supply as u128))
+            ((token_account_balance as u128) * (available_rewards as u128) / (token_supply as u128))
                 as u64
         }
     };

--- a/program/tests/setup.rs
+++ b/program/tests/setup.rs
@@ -128,13 +128,14 @@ pub async fn setup_system_account(
 pub async fn setup_holder_rewards_pool_account(
     context: &mut ProgramTestContext,
     holder_rewards_pool_address: &Pubkey,
+    excess_lamports: u64,
     total_rewards: u64,
 ) {
     let state = HolderRewardsPool { total_rewards };
     let data = bytemuck::bytes_of(&state).to_vec();
 
     let rent = context.banks_client.get_rent().await.unwrap();
-    let lamports = rent.minimum_balance(data.len()) + total_rewards;
+    let lamports = rent.minimum_balance(data.len()) + excess_lamports;
 
     context.set_account(
         holder_rewards_pool_address,

--- a/program/tests/setup.rs
+++ b/program/tests/setup.rs
@@ -12,10 +12,10 @@ use {
     },
     spl_token_2022::{
         extension::{
-            transfer_hook::TransferHook, BaseStateWithExtensionsMut, ExtensionType,
-            StateWithExtensionsMut,
+            transfer_hook::{TransferHook, TransferHookAccount},
+            BaseStateWithExtensionsMut, ExtensionType, StateWithExtensionsMut,
         },
-        state::Mint,
+        state::{Account as TokenAccount, AccountState, Mint},
     },
 };
 
@@ -58,6 +58,48 @@ pub async fn setup_mint(
 
     context.set_account(
         mint,
+        &AccountSharedData::from(Account {
+            lamports,
+            data,
+            owner: spl_token_2022::id(),
+            ..Account::default()
+        }),
+    );
+}
+
+pub async fn setup_token_account(
+    context: &mut ProgramTestContext,
+    token_account: &Pubkey,
+    owner: &Pubkey,
+    mint: &Pubkey,
+    amount: u64,
+) {
+    let account_size = ExtensionType::try_calculate_account_len::<TokenAccount>(&[
+        ExtensionType::TransferHookAccount,
+    ])
+    .unwrap();
+
+    let rent = context.banks_client.get_rent().await.unwrap();
+    let lamports = rent.minimum_balance(account_size);
+
+    let mut data = vec![0; account_size];
+    {
+        let mut state =
+            StateWithExtensionsMut::<TokenAccount>::unpack_uninitialized(&mut data).unwrap();
+        state.init_extension::<TransferHookAccount>(true).unwrap();
+        state.base = TokenAccount {
+            amount,
+            mint: *mint,
+            owner: *owner,
+            state: AccountState::Initialized,
+            ..TokenAccount::default()
+        };
+        state.pack_base();
+        state.init_account_type().unwrap();
+    }
+
+    context.set_account(
+        token_account,
         &AccountSharedData::from(Account {
             lamports,
             data,


### PR DESCRIPTION
This PR introduces the processor for the `InitializeHolderRewards` instruction.

This instruction initializes a holder rewards account for a token account,
calculating its share of the total rewards to store in the new account state.