### PR TITLE
Add Rust nightly to CI

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -3,7 +3,7 @@ name: Setup environment
 inputs:
   cache:
     description: Enable caching
-    default: 'true'
+    default: "true"
   node:
     description: The Node.js version to install
     required: true
@@ -11,7 +11,7 @@ inputs:
     description: The Solana version to install
 
 runs:
-  using: 'composite'
+  using: "composite"
   steps:
     - name: Setup pnpm
       uses: pnpm/action-setup@v3
@@ -19,20 +19,12 @@ runs:
       uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.node }}
-        cache: 'pnpm'
+        cache: "pnpm"
     - name: Install dependencies
       run: pnpm install --frozen-lockfile
       shell: bash
     - name: Install Rust
-      uses: metaplex-foundation/actions/install-rust@v1
-      with:
-        toolchain: stable
-        components: clippy,rustfmt
-    - name: Install Rust Nightly
-      uses: metaplex-foundation/actions/install-rust@v1
-      with:
-        toolchain: nightly
-        components: clippy,rustfmt
+      uses: dtolnay/rust-toolchain@stable
     - name: Install Solana
       if: ${{ inputs.solana != '' }}
       uses: metaplex-foundation/actions/install-solana@v1

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -3,7 +3,7 @@ name: Setup environment
 inputs:
   cache:
     description: Enable caching
-    default: "true"
+    default: 'true'
   node:
     description: The Node.js version to install
     required: true
@@ -11,7 +11,7 @@ inputs:
     description: The Solana version to install
 
 runs:
-  using: "composite"
+  using: 'composite'
   steps:
     - name: Setup pnpm
       uses: pnpm/action-setup@v3
@@ -19,10 +19,20 @@ runs:
       uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.node }}
-        cache: "pnpm"
+        cache: 'pnpm'
     - name: Install dependencies
       run: pnpm install --frozen-lockfile
       shell: bash
+    - name: Install Rust
+      uses: metaplex-foundation/actions/install-rust@v1
+      with:
+        toolchain: stable
+        components: clippy,rustfmt
+    - name: Install Rust Nightly
+      uses: metaplex-foundation/actions/install-rust@v1
+      with:
+        toolchain: nightly
+        components: clippy,rustfmt
     - name: Install Solana
       if: ${{ inputs.solana != '' }}
       uses: metaplex-foundation/actions/install-solana@v1

--- a/cargo-nightly
+++ b/cargo-nightly
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+here=$(dirname "$0")
+source "${here}"/ci/rust-version.sh nightly
+# shellcheck disable=SC2054 # rust_nightly is sourced from rust-version.sh
+toolchain="$rust_nightly"
+set -x
+exec cargo "+${toolchain}" "${@}"

--- a/ci/read-cargo-variable.sh
+++ b/ci/read-cargo-variable.sh
@@ -1,0 +1,14 @@
+# source this file
+
+readCargoVariable() {
+  declare variable="$1"
+  declare Cargo_toml="$2"
+
+  while read -r name equals value _; do
+    if [[ $name = "$variable" && $equals = = ]]; then
+      echo "${value//\"/}"
+      return
+    fi
+  done < <(cat "$Cargo_toml")
+  echo "Unable to locate $variable in $Cargo_toml" 1>&2
+}

--- a/ci/rust-version.sh
+++ b/ci/rust-version.sh
@@ -1,0 +1,66 @@
+#
+# This file maintains the rust versions for use by CI.
+#
+# Obtain the environment variables without any automatic toolchain updating:
+#   $ source ci/rust-version.sh
+#
+# Obtain the environment variables updating both stable and nightly, only stable, or
+# only nightly:
+#   $ source ci/rust-version.sh all
+#   $ source ci/rust-version.sh stable
+#   $ source ci/rust-version.sh nightly
+
+# Then to build with either stable or nightly:
+#   $ cargo +"$rust_stable" build
+#   $ cargo +"$rust_nightly" build
+#
+
+if [[ -n $RUST_STABLE_VERSION ]]; then
+  stable_version="$RUST_STABLE_VERSION"
+else
+  base="$(dirname "${BASH_SOURCE[0]}")"
+  source "$base/read-cargo-variable.sh"
+  stable_version=$(readCargoVariable channel "$base/../rust-toolchain.toml")
+fi
+
+if [[ -n $RUST_NIGHTLY_VERSION ]]; then
+  nightly_version="$RUST_NIGHTLY_VERSION"
+else
+  nightly_version=2023-10-05
+fi
+
+export rust_stable="$stable_version"
+export rust_stable_docker_image=solanalabs/rust:"$stable_version"
+
+export rust_nightly=nightly-"$nightly_version"
+export rust_nightly_docker_image=solanalabs/rust-nightly:"$nightly_version"
+
+[[ -z $1 ]] || (
+
+  rustup_install() {
+    declare toolchain=$1
+    if ! cargo +"$toolchain" -V > /dev/null; then
+      echo "$0: Missing toolchain? Installing...: $toolchain" >&2
+      rustup install "$toolchain"
+      cargo +"$toolchain" -V
+    fi
+  }
+
+  set -e
+  cd "$(dirname "${BASH_SOURCE[0]}")"
+  case $1 in
+  stable)
+    rustup_install "$rust_stable"
+    ;;
+  nightly)
+    rustup_install "$rust_nightly"
+    ;;
+  all)
+    rustup_install "$rust_stable"
+    rustup_install "$rust_nightly"
+    ;;
+  *)
+    echo "$0: Note: ignoring unknown argument: $1" >&2
+    ;;
+  esac
+)

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "nightly-2023-10-05"
+components = [ "rustfmt", "clippy" ]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,2 @@
 [toolchain]
-channel = "nightly-2023-10-05"
-components = [ "rustfmt", "clippy" ]
+channel = "1.76.0"


### PR DESCRIPTION
#### Problem

The CI from `create-solana-program` doesn't come with Rust installed natively.
Instead, it uses the `rustc` version from the `solana` install, which only allows you
to run `cargo-build-sbf` and `cargo-test-sbf`.

Commands like `cargo clippy` and `cargo +nightly fmt` won't work in CI.

#### Summary of Changes

Add a setup step for Rust nightly.

**Note:** This may be useful to backport to the `create-solana-program` tool.