### PR TITLE
Processor: Transfer Hook

### DIFF
--- a/program/tests/transfer_hook.rs
+++ b/program/tests/transfer_hook.rs
@@ -1,0 +1,1318 @@
+//! Most of these test cases are checked by Token-2022, but it doesn't hurt to
+//! check them by directly invoking the program's `ExecuteInstruction`.
+
+// #![cfg(feature = "test-sbf")]
+#![allow(clippy::arithmetic_side_effects)]
+
+mod setup;
+
+use {
+    paladin_rewards_program::{
+        error::PaladinRewardsError,
+        state::{get_holder_rewards_address, get_holder_rewards_pool_address, HolderRewards},
+    },
+    setup::{
+        setup, setup_extra_metas_account, setup_holder_rewards_account,
+        setup_holder_rewards_pool_account, setup_mint, setup_token_account,
+        setup_token_account_transferring,
+    },
+    solana_program_test::*,
+    solana_sdk::{
+        account::AccountSharedData,
+        instruction::{AccountMeta, Instruction, InstructionError},
+        pubkey::Pubkey,
+        signature::Keypair,
+        signer::Signer,
+        transaction::{Transaction, TransactionError},
+    },
+    spl_associated_token_account::get_associated_token_address,
+    spl_transfer_hook_interface::{
+        error::TransferHookError, get_extra_account_metas_address,
+        offchain::add_extra_account_metas_for_execute,
+    },
+    test_case::test_case,
+};
+
+#[allow(clippy::too_many_arguments)]
+fn execute_with_extra_metas_instruction(
+    source: &Pubkey,
+    mint: &Pubkey,
+    destination: &Pubkey,
+    owner: &Pubkey,
+    holder_rewards_pool: &Pubkey,
+    source_holder_rewards: &Pubkey,
+    destination_holder_rewards: &Pubkey,
+    amount: u64,
+) -> Instruction {
+    spl_transfer_hook_interface::instruction::execute_with_extra_account_metas(
+        &paladin_rewards_program::id(),
+        source,
+        mint,
+        destination,
+        owner,
+        &Pubkey::new_unique(), // (Extra metas) Doesn't matter if we're invoking directly.
+        &[
+            AccountMeta::new_readonly(*holder_rewards_pool, false),
+            AccountMeta::new(*source_holder_rewards, false),
+            AccountMeta::new(*destination_holder_rewards, false),
+        ],
+        amount,
+    )
+}
+
+async fn transfer_with_extra_metas_instruction(
+    context: &mut ProgramTestContext,
+    source: &Pubkey,
+    mint: &Pubkey,
+    destination: &Pubkey,
+    owner: &Pubkey,
+    amount: u64,
+    decimals: u8,
+) -> Instruction {
+    let mut instruction = spl_token_2022::instruction::transfer_checked(
+        &spl_token_2022::id(),
+        source,
+        mint,
+        destination,
+        owner,
+        &[],
+        amount,
+        decimals,
+    )
+    .unwrap();
+
+    // The closure required by `add_extra_account_metas_for_execute` is a pain
+    // in the ass, so just grab the extra metas account ahead of time, since we
+    // know our extra metas don't require account data, therefore don't require
+    // loading any other accounts.
+    let extra_metas_address = get_extra_account_metas_address(mint, &paladin_rewards_program::id());
+    let extra_metas_account = context
+        .banks_client
+        .get_account(extra_metas_address)
+        .await
+        .unwrap()
+        .unwrap();
+
+    add_extra_account_metas_for_execute(
+        &mut instruction,
+        &paladin_rewards_program::id(),
+        source,
+        mint,
+        destination,
+        owner,
+        amount,
+        |key| {
+            let data = if key.eq(&extra_metas_address) {
+                Some(extra_metas_account.data.clone())
+            } else {
+                None
+            };
+            async move { Ok(data) }
+        },
+    )
+    .await
+    .unwrap();
+
+    instruction
+}
+
+#[tokio::test]
+async fn fail_mint_invalid_data() {
+    let mint = Pubkey::new_unique();
+    let holder_rewards_pool = get_holder_rewards_pool_address(&mint);
+
+    let source_owner = Keypair::new();
+    let source_token_account = get_associated_token_address(&source_owner.pubkey(), &mint);
+    let source_holder_rewards = get_holder_rewards_address(&source_token_account);
+
+    let destination_owner = Pubkey::new_unique();
+    let destination_token_account = get_associated_token_address(&destination_owner, &mint);
+    let destination_holder_rewards = get_holder_rewards_address(&destination_token_account);
+
+    let mut context = setup().start_with_context().await;
+
+    // Set up a mint with invalid data.
+    {
+        context.set_account(
+            &mint,
+            &AccountSharedData::new_data(100_000_000, &vec![5; 165], &spl_token_2022::id())
+                .unwrap(),
+        );
+    }
+
+    let instruction = execute_with_extra_metas_instruction(
+        &source_token_account,
+        &mint,
+        &destination_token_account,
+        &source_owner.pubkey(),
+        &holder_rewards_pool,
+        &source_holder_rewards,
+        &destination_holder_rewards,
+        0,
+    );
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[instruction],
+        Some(&context.payer.pubkey()),
+        &[&context.payer],
+        context.last_blockhash,
+    );
+
+    let err = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
+        .unwrap();
+
+    assert_eq!(
+        err,
+        TransactionError::InstructionError(0, InstructionError::InvalidAccountData)
+    );
+}
+
+#[tokio::test]
+async fn fail_holder_rewards_pool_incorrect_owner() {
+    let mint = Pubkey::new_unique();
+    let holder_rewards_pool = get_holder_rewards_pool_address(&mint);
+
+    let source_owner = Keypair::new();
+    let source_token_account = get_associated_token_address(&source_owner.pubkey(), &mint);
+    let source_holder_rewards = get_holder_rewards_address(&source_token_account);
+
+    let destination_owner = Pubkey::new_unique();
+    let destination_token_account = get_associated_token_address(&destination_owner, &mint);
+    let destination_holder_rewards = get_holder_rewards_address(&destination_token_account);
+
+    let mut context = setup().start_with_context().await;
+    setup_mint(&mut context, &mint, &Pubkey::new_unique(), 100).await;
+
+    // Set up a holder rewards pool account with incorrect owner.
+    {
+        context.set_account(
+            &holder_rewards_pool,
+            &AccountSharedData::new_data(100_000_000, &vec![5; 8], &Pubkey::new_unique()).unwrap(),
+        );
+    }
+
+    let instruction = execute_with_extra_metas_instruction(
+        &source_token_account,
+        &mint,
+        &destination_token_account,
+        &source_owner.pubkey(),
+        &holder_rewards_pool,
+        &source_holder_rewards,
+        &destination_holder_rewards,
+        0,
+    );
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[instruction],
+        Some(&context.payer.pubkey()),
+        &[&context.payer],
+        context.last_blockhash,
+    );
+
+    let err = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
+        .unwrap();
+
+    assert_eq!(
+        err,
+        TransactionError::InstructionError(0, InstructionError::InvalidAccountOwner)
+    );
+}
+
+#[tokio::test]
+async fn fail_holder_rewards_pool_incorrect_address() {
+    let mint = Pubkey::new_unique();
+    let holder_rewards_pool = Pubkey::new_unique(); // Incorrect holder rewards pool address.
+
+    let source_owner = Keypair::new();
+    let source_token_account = get_associated_token_address(&source_owner.pubkey(), &mint);
+    let source_holder_rewards = get_holder_rewards_address(&source_token_account);
+
+    let destination_owner = Pubkey::new_unique();
+    let destination_token_account = get_associated_token_address(&destination_owner, &mint);
+    let destination_holder_rewards = get_holder_rewards_address(&destination_token_account);
+
+    let mut context = setup().start_with_context().await;
+    setup_holder_rewards_pool_account(&mut context, &holder_rewards_pool, 0, 0).await;
+    setup_mint(&mut context, &mint, &Pubkey::new_unique(), 100).await;
+
+    let instruction = execute_with_extra_metas_instruction(
+        &source_token_account,
+        &mint,
+        &destination_token_account,
+        &source_owner.pubkey(),
+        &holder_rewards_pool,
+        &source_holder_rewards,
+        &destination_holder_rewards,
+        0,
+    );
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[instruction],
+        Some(&context.payer.pubkey()),
+        &[&context.payer],
+        context.last_blockhash,
+    );
+
+    let err = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
+        .unwrap();
+
+    assert_eq!(
+        err,
+        TransactionError::InstructionError(
+            0,
+            InstructionError::Custom(PaladinRewardsError::IncorrectHolderRewardsPoolAddress as u32)
+        )
+    );
+}
+
+#[tokio::test]
+async fn fail_holder_rewards_pool_invalid_data() {
+    let mint = Pubkey::new_unique();
+    let holder_rewards_pool = get_holder_rewards_pool_address(&mint);
+
+    let source_owner = Keypair::new();
+    let source_token_account = get_associated_token_address(&source_owner.pubkey(), &mint);
+    let source_holder_rewards = get_holder_rewards_address(&source_token_account);
+
+    let destination_owner = Pubkey::new_unique();
+    let destination_token_account = get_associated_token_address(&destination_owner, &mint);
+    let destination_holder_rewards = get_holder_rewards_address(&destination_token_account);
+
+    let mut context = setup().start_with_context().await;
+    setup_mint(&mut context, &mint, &Pubkey::new_unique(), 100).await;
+
+    // Set up a holder rewards pool account with invalid data.
+    {
+        context.set_account(
+            &holder_rewards_pool,
+            &AccountSharedData::new_data(
+                100_000_000,
+                &vec![5; 165],
+                &paladin_rewards_program::id(),
+            )
+            .unwrap(),
+        );
+    }
+
+    let instruction = execute_with_extra_metas_instruction(
+        &source_token_account,
+        &mint,
+        &destination_token_account,
+        &source_owner.pubkey(),
+        &holder_rewards_pool,
+        &source_holder_rewards,
+        &destination_holder_rewards,
+        0,
+    );
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[instruction],
+        Some(&context.payer.pubkey()),
+        &[&context.payer],
+        context.last_blockhash,
+    );
+
+    let err = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
+        .unwrap();
+
+    assert_eq!(
+        err,
+        TransactionError::InstructionError(0, InstructionError::InvalidAccountData)
+    );
+}
+
+#[tokio::test]
+async fn fail_source_holder_rewards_incorrect_address() {
+    let mint = Pubkey::new_unique();
+    let holder_rewards_pool = get_holder_rewards_pool_address(&mint);
+
+    let source_owner = Keypair::new();
+    let source_token_account = get_associated_token_address(&source_owner.pubkey(), &mint);
+    let source_holder_rewards = Pubkey::new_unique(); // Incorrect source holder rewards address.
+
+    let destination_owner = Pubkey::new_unique();
+    let destination_token_account = get_associated_token_address(&destination_owner, &mint);
+    let destination_holder_rewards = get_holder_rewards_address(&destination_token_account);
+
+    let mut context = setup().start_with_context().await;
+    setup_holder_rewards_pool_account(&mut context, &holder_rewards_pool, 0, 0).await;
+    setup_holder_rewards_account(&mut context, &source_holder_rewards, 0, 0).await;
+    setup_mint(&mut context, &mint, &Pubkey::new_unique(), 100).await;
+
+    let instruction = execute_with_extra_metas_instruction(
+        &source_token_account,
+        &mint,
+        &destination_token_account,
+        &source_owner.pubkey(),
+        &holder_rewards_pool,
+        &source_holder_rewards,
+        &destination_holder_rewards,
+        0,
+    );
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[instruction],
+        Some(&context.payer.pubkey()),
+        &[&context.payer],
+        context.last_blockhash,
+    );
+
+    let err = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
+        .unwrap();
+
+    assert_eq!(
+        err,
+        TransactionError::InstructionError(
+            0,
+            InstructionError::Custom(PaladinRewardsError::IncorrectHolderRewardsAddress as u32)
+        )
+    );
+}
+
+#[tokio::test]
+async fn fail_source_holder_rewards_invalid_data() {
+    let mint = Pubkey::new_unique();
+    let holder_rewards_pool = get_holder_rewards_pool_address(&mint);
+
+    let source_owner = Keypair::new();
+    let source_token_account = get_associated_token_address(&source_owner.pubkey(), &mint);
+    let source_holder_rewards = get_holder_rewards_address(&source_token_account);
+
+    let destination_owner = Pubkey::new_unique();
+    let destination_token_account = get_associated_token_address(&destination_owner, &mint);
+    let destination_holder_rewards = get_holder_rewards_address(&destination_token_account);
+
+    let mut context = setup().start_with_context().await;
+    setup_holder_rewards_pool_account(&mut context, &holder_rewards_pool, 0, 0).await;
+    setup_holder_rewards_account(&mut context, &source_holder_rewards, 0, 0).await;
+    setup_mint(&mut context, &mint, &Pubkey::new_unique(), 100).await;
+
+    // Setup source holder rewards account with invalid data.
+    {
+        context.set_account(
+            &source_holder_rewards,
+            &AccountSharedData::new_data(
+                100_000_000,
+                &vec![5; 165],
+                &paladin_rewards_program::id(),
+            )
+            .unwrap(),
+        );
+    }
+
+    let instruction = execute_with_extra_metas_instruction(
+        &source_token_account,
+        &mint,
+        &destination_token_account,
+        &source_owner.pubkey(),
+        &holder_rewards_pool,
+        &source_holder_rewards,
+        &destination_holder_rewards,
+        0,
+    );
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[instruction],
+        Some(&context.payer.pubkey()),
+        &[&context.payer],
+        context.last_blockhash,
+    );
+
+    let err = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
+        .unwrap();
+
+    assert_eq!(
+        err,
+        TransactionError::InstructionError(0, InstructionError::InvalidAccountData)
+    );
+}
+
+#[tokio::test]
+async fn fail_source_token_account_invalid_data() {
+    let mint = Pubkey::new_unique();
+    let holder_rewards_pool = get_holder_rewards_pool_address(&mint);
+
+    let source_owner = Keypair::new();
+    let source_token_account = get_associated_token_address(&source_owner.pubkey(), &mint);
+    let source_holder_rewards = get_holder_rewards_address(&source_token_account);
+
+    let destination_owner = Pubkey::new_unique();
+    let destination_token_account = get_associated_token_address(&destination_owner, &mint);
+    let destination_holder_rewards = get_holder_rewards_address(&destination_token_account);
+
+    let mut context = setup().start_with_context().await;
+    setup_holder_rewards_pool_account(&mut context, &holder_rewards_pool, 0, 0).await;
+    setup_holder_rewards_account(&mut context, &source_holder_rewards, 0, 0).await;
+    setup_mint(&mut context, &mint, &Pubkey::new_unique(), 100).await;
+
+    // Set up source token account with invalid data.
+    {
+        context.set_account(
+            &source_token_account,
+            &AccountSharedData::new_data(100_000_000, &vec![5; 165], &spl_token_2022::id())
+                .unwrap(),
+        );
+    }
+
+    let instruction = execute_with_extra_metas_instruction(
+        &source_token_account,
+        &mint,
+        &destination_token_account,
+        &source_owner.pubkey(),
+        &holder_rewards_pool,
+        &source_holder_rewards,
+        &destination_holder_rewards,
+        0,
+    );
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[instruction],
+        Some(&context.payer.pubkey()),
+        &[&context.payer],
+        context.last_blockhash,
+    );
+
+    let err = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
+        .unwrap();
+
+    assert_eq!(
+        err,
+        TransactionError::InstructionError(0, InstructionError::InvalidAccountData)
+    );
+}
+
+#[tokio::test]
+async fn fail_source_token_account_mint_mismatch() {
+    let mint = Pubkey::new_unique();
+    let holder_rewards_pool = get_holder_rewards_pool_address(&mint);
+
+    let source_owner = Keypair::new();
+    let source_token_account = get_associated_token_address(&source_owner.pubkey(), &mint);
+    let source_holder_rewards = get_holder_rewards_address(&source_token_account);
+
+    let destination_owner = Pubkey::new_unique();
+    let destination_token_account = get_associated_token_address(&destination_owner, &mint);
+    let destination_holder_rewards = get_holder_rewards_address(&destination_token_account);
+
+    let mut context = setup().start_with_context().await;
+    setup_holder_rewards_pool_account(&mut context, &holder_rewards_pool, 0, 0).await;
+    setup_holder_rewards_account(&mut context, &source_holder_rewards, 0, 0).await;
+    setup_token_account_transferring(
+        &mut context,
+        &source_token_account,
+        &source_owner.pubkey(),
+        &Pubkey::new_unique(), // Incorrect mint.
+        10,
+    )
+    .await;
+    setup_mint(&mut context, &mint, &Pubkey::new_unique(), 100).await;
+
+    let instruction = execute_with_extra_metas_instruction(
+        &source_token_account,
+        &mint,
+        &destination_token_account,
+        &source_owner.pubkey(),
+        &holder_rewards_pool,
+        &source_holder_rewards,
+        &destination_holder_rewards,
+        0,
+    );
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[instruction],
+        Some(&context.payer.pubkey()),
+        &[&context.payer],
+        context.last_blockhash,
+    );
+
+    let err = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
+        .unwrap();
+
+    assert_eq!(
+        err,
+        TransactionError::InstructionError(
+            0,
+            InstructionError::Custom(PaladinRewardsError::TokenAccountMintMismatch as u32)
+        )
+    );
+}
+
+#[tokio::test]
+async fn fail_source_token_account_not_transferring() {
+    let mint = Pubkey::new_unique();
+    let holder_rewards_pool = get_holder_rewards_pool_address(&mint);
+
+    let source_owner = Keypair::new();
+    let source_token_account = get_associated_token_address(&source_owner.pubkey(), &mint);
+    let source_holder_rewards = get_holder_rewards_address(&source_token_account);
+
+    let destination_owner = Pubkey::new_unique();
+    let destination_token_account = get_associated_token_address(&destination_owner, &mint);
+    let destination_holder_rewards = get_holder_rewards_address(&destination_token_account);
+
+    let mut context = setup().start_with_context().await;
+    setup_holder_rewards_pool_account(&mut context, &holder_rewards_pool, 0, 0).await;
+    setup_holder_rewards_account(&mut context, &source_holder_rewards, 0, 0).await;
+    // Not transferring.
+    setup_token_account(
+        &mut context,
+        &source_token_account,
+        &source_owner.pubkey(),
+        &mint,
+        10,
+    )
+    .await;
+    setup_mint(&mut context, &mint, &Pubkey::new_unique(), 100).await;
+
+    let instruction = execute_with_extra_metas_instruction(
+        &source_token_account,
+        &mint,
+        &destination_token_account,
+        &source_owner.pubkey(),
+        &holder_rewards_pool,
+        &source_holder_rewards,
+        &destination_holder_rewards,
+        0,
+    );
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[instruction],
+        Some(&context.payer.pubkey()),
+        &[&context.payer],
+        context.last_blockhash,
+    );
+
+    let err = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
+        .unwrap();
+
+    assert_eq!(
+        err,
+        TransactionError::InstructionError(
+            0,
+            InstructionError::Custom(TransferHookError::ProgramCalledOutsideOfTransfer as u32)
+        )
+    );
+}
+
+#[tokio::test]
+async fn fail_destination_holder_rewards_incorrect_address() {
+    let mint = Pubkey::new_unique();
+    let holder_rewards_pool = get_holder_rewards_pool_address(&mint);
+
+    let source_owner = Keypair::new();
+    let source_token_account = get_associated_token_address(&source_owner.pubkey(), &mint);
+    let source_holder_rewards = get_holder_rewards_address(&source_token_account);
+
+    let destination_owner = Pubkey::new_unique();
+    let destination_token_account = get_associated_token_address(&destination_owner, &mint);
+    let destination_holder_rewards = Pubkey::new_unique(); // Incorrect source holder rewards address.
+
+    let mut context = setup().start_with_context().await;
+    setup_holder_rewards_pool_account(&mut context, &holder_rewards_pool, 0, 0).await;
+    setup_holder_rewards_account(&mut context, &source_holder_rewards, 0, 0).await;
+    setup_holder_rewards_account(&mut context, &destination_holder_rewards, 0, 0).await;
+    setup_token_account_transferring(
+        &mut context,
+        &source_token_account,
+        &source_owner.pubkey(),
+        &mint,
+        10,
+    )
+    .await;
+    setup_mint(&mut context, &mint, &Pubkey::new_unique(), 100).await;
+
+    let instruction = execute_with_extra_metas_instruction(
+        &source_token_account,
+        &mint,
+        &destination_token_account,
+        &source_owner.pubkey(),
+        &holder_rewards_pool,
+        &source_holder_rewards,
+        &destination_holder_rewards,
+        0,
+    );
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[instruction],
+        Some(&context.payer.pubkey()),
+        &[&context.payer],
+        context.last_blockhash,
+    );
+
+    let err = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
+        .unwrap();
+
+    assert_eq!(
+        err,
+        TransactionError::InstructionError(
+            0,
+            InstructionError::Custom(PaladinRewardsError::IncorrectHolderRewardsAddress as u32)
+        )
+    );
+}
+
+#[tokio::test]
+async fn fail_destination_holder_rewards_invalid_data() {
+    let mint = Pubkey::new_unique();
+    let holder_rewards_pool = get_holder_rewards_pool_address(&mint);
+
+    let source_owner = Keypair::new();
+    let source_token_account = get_associated_token_address(&source_owner.pubkey(), &mint);
+    let source_holder_rewards = get_holder_rewards_address(&source_token_account);
+
+    let destination_owner = Pubkey::new_unique();
+    let destination_token_account = get_associated_token_address(&destination_owner, &mint);
+    let destination_holder_rewards = get_holder_rewards_address(&destination_token_account);
+
+    let mut context = setup().start_with_context().await;
+    setup_holder_rewards_pool_account(&mut context, &holder_rewards_pool, 0, 0).await;
+    setup_holder_rewards_account(&mut context, &source_holder_rewards, 0, 0).await;
+    setup_token_account_transferring(
+        &mut context,
+        &source_token_account,
+        &source_owner.pubkey(),
+        &mint,
+        10,
+    )
+    .await;
+    setup_mint(&mut context, &mint, &Pubkey::new_unique(), 100).await;
+
+    // Setup destination holder rewards account with invalid data.
+    {
+        context.set_account(
+            &destination_holder_rewards,
+            &AccountSharedData::new_data(
+                100_000_000,
+                &vec![5; 165],
+                &paladin_rewards_program::id(),
+            )
+            .unwrap(),
+        );
+    }
+
+    let instruction = execute_with_extra_metas_instruction(
+        &source_token_account,
+        &mint,
+        &destination_token_account,
+        &source_owner.pubkey(),
+        &holder_rewards_pool,
+        &source_holder_rewards,
+        &destination_holder_rewards,
+        0,
+    );
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[instruction],
+        Some(&context.payer.pubkey()),
+        &[&context.payer],
+        context.last_blockhash,
+    );
+
+    let err = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
+        .unwrap();
+
+    assert_eq!(
+        err,
+        TransactionError::InstructionError(0, InstructionError::InvalidAccountData)
+    );
+}
+
+#[tokio::test]
+async fn fail_destination_token_account_invalid_data() {
+    let mint = Pubkey::new_unique();
+    let holder_rewards_pool = get_holder_rewards_pool_address(&mint);
+
+    let source_owner = Keypair::new();
+    let source_token_account = get_associated_token_address(&source_owner.pubkey(), &mint);
+    let source_holder_rewards = get_holder_rewards_address(&source_token_account);
+
+    let destination_owner = Pubkey::new_unique();
+    let destination_token_account = get_associated_token_address(&destination_owner, &mint);
+    let destination_holder_rewards = get_holder_rewards_address(&destination_token_account);
+
+    let mut context = setup().start_with_context().await;
+    setup_holder_rewards_pool_account(&mut context, &holder_rewards_pool, 0, 0).await;
+    setup_holder_rewards_account(&mut context, &source_holder_rewards, 0, 0).await;
+    setup_holder_rewards_account(&mut context, &destination_holder_rewards, 0, 0).await;
+    setup_token_account_transferring(
+        &mut context,
+        &source_token_account,
+        &source_owner.pubkey(),
+        &mint,
+        10,
+    )
+    .await;
+    setup_mint(&mut context, &mint, &Pubkey::new_unique(), 100).await;
+
+    // Set up destination token account with invalid data.
+    {
+        context.set_account(
+            &destination_token_account,
+            &AccountSharedData::new_data(100_000_000, &vec![5; 165], &spl_token_2022::id())
+                .unwrap(),
+        );
+    }
+
+    let instruction = execute_with_extra_metas_instruction(
+        &source_token_account,
+        &mint,
+        &destination_token_account,
+        &source_owner.pubkey(),
+        &holder_rewards_pool,
+        &source_holder_rewards,
+        &destination_holder_rewards,
+        0,
+    );
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[instruction],
+        Some(&context.payer.pubkey()),
+        &[&context.payer],
+        context.last_blockhash,
+    );
+
+    let err = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
+        .unwrap();
+
+    assert_eq!(
+        err,
+        TransactionError::InstructionError(0, InstructionError::InvalidAccountData)
+    );
+}
+
+#[tokio::test]
+async fn fail_destination_token_account_mint_mismatch() {
+    let mint = Pubkey::new_unique();
+    let holder_rewards_pool = get_holder_rewards_pool_address(&mint);
+
+    let source_owner = Keypair::new();
+    let source_token_account = get_associated_token_address(&source_owner.pubkey(), &mint);
+    let source_holder_rewards = get_holder_rewards_address(&source_token_account);
+
+    let destination_owner = Pubkey::new_unique();
+    let destination_token_account = get_associated_token_address(&destination_owner, &mint);
+    let destination_holder_rewards = get_holder_rewards_address(&destination_token_account);
+
+    let mut context = setup().start_with_context().await;
+    setup_holder_rewards_pool_account(&mut context, &holder_rewards_pool, 0, 0).await;
+    setup_holder_rewards_account(&mut context, &source_holder_rewards, 0, 0).await;
+    setup_holder_rewards_account(&mut context, &destination_holder_rewards, 0, 0).await;
+    setup_token_account_transferring(
+        &mut context,
+        &source_token_account,
+        &source_owner.pubkey(),
+        &mint,
+        10,
+    )
+    .await;
+    setup_token_account_transferring(
+        &mut context,
+        &destination_token_account,
+        &destination_owner,
+        &Pubkey::new_unique(), // Incorrect mint.
+        10,
+    )
+    .await;
+    setup_mint(&mut context, &mint, &Pubkey::new_unique(), 100).await;
+
+    let instruction = execute_with_extra_metas_instruction(
+        &source_token_account,
+        &mint,
+        &destination_token_account,
+        &source_owner.pubkey(),
+        &holder_rewards_pool,
+        &source_holder_rewards,
+        &destination_holder_rewards,
+        0,
+    );
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[instruction],
+        Some(&context.payer.pubkey()),
+        &[&context.payer],
+        context.last_blockhash,
+    );
+
+    let err = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
+        .unwrap();
+
+    assert_eq!(
+        err,
+        TransactionError::InstructionError(
+            0,
+            InstructionError::Custom(PaladinRewardsError::TokenAccountMintMismatch as u32)
+        )
+    );
+}
+
+#[tokio::test]
+async fn fail_destination_token_account_not_transferring() {
+    let mint = Pubkey::new_unique();
+    let holder_rewards_pool = get_holder_rewards_pool_address(&mint);
+
+    let source_owner = Keypair::new();
+    let source_token_account = get_associated_token_address(&source_owner.pubkey(), &mint);
+    let source_holder_rewards = get_holder_rewards_address(&source_token_account);
+
+    let destination_owner = Pubkey::new_unique();
+    let destination_token_account = get_associated_token_address(&destination_owner, &mint);
+    let destination_holder_rewards = get_holder_rewards_address(&destination_token_account);
+
+    let mut context = setup().start_with_context().await;
+    setup_holder_rewards_pool_account(&mut context, &holder_rewards_pool, 0, 0).await;
+    setup_holder_rewards_account(&mut context, &source_holder_rewards, 0, 0).await;
+    setup_holder_rewards_account(&mut context, &destination_holder_rewards, 0, 0).await;
+    setup_token_account_transferring(
+        &mut context,
+        &source_token_account,
+        &source_owner.pubkey(),
+        &mint,
+        10,
+    )
+    .await;
+    // Not transferring.
+    setup_token_account(
+        &mut context,
+        &destination_token_account,
+        &destination_owner,
+        &mint,
+        10,
+    )
+    .await;
+    setup_mint(&mut context, &mint, &Pubkey::new_unique(), 100).await;
+
+    let instruction = execute_with_extra_metas_instruction(
+        &source_token_account,
+        &mint,
+        &destination_token_account,
+        &source_owner.pubkey(),
+        &holder_rewards_pool,
+        &source_holder_rewards,
+        &destination_holder_rewards,
+        0,
+    );
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[instruction],
+        Some(&context.payer.pubkey()),
+        &[&context.payer],
+        context.last_blockhash,
+    );
+
+    let err = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
+        .unwrap();
+
+    assert_eq!(
+        err,
+        TransactionError::InstructionError(
+            0,
+            InstructionError::Custom(TransferHookError::ProgramCalledOutsideOfTransfer as u32)
+        )
+    );
+}
+
+struct System {
+    token_supply: u64,
+    total_rewards: u64,
+    pool_excess_lamports: u64,
+}
+
+struct SystemAddresses {
+    mint: Pubkey,
+    holder_rewards_pool: Pubkey,
+}
+
+impl SystemAddresses {
+    fn new() -> Self {
+        let mint = Pubkey::new_unique();
+        let holder_rewards_pool = get_holder_rewards_pool_address(&mint);
+        Self {
+            mint,
+            holder_rewards_pool,
+        }
+    }
+}
+
+struct Holder {
+    token_account_balance: u64,
+    last_seen_total_rewards: u64,
+    unharvested_rewards: u64,
+    expected_unharvested_rewards: u64,
+}
+
+struct HolderAddresses {
+    owner: Pubkey,
+    token_account: Pubkey,
+    holder_rewards: Pubkey,
+}
+
+impl HolderAddresses {
+    fn new(owner: &Pubkey, mint: &Pubkey) -> Self {
+        let token_account = get_associated_token_address(owner, mint);
+        let holder_rewards = get_holder_rewards_address(&token_account);
+        Self {
+            owner: *owner,
+            token_account,
+            holder_rewards,
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn setup_direct_invoke(
+    context: &mut ProgramTestContext,
+    system: &System,
+    system_addresses: &SystemAddresses,
+    source: &Holder,
+    source_addresses: &HolderAddresses,
+    destination: &Holder,
+    destination_addresses: &HolderAddresses,
+    transfer_amount: u64,
+) {
+    let System {
+        token_supply,
+        total_rewards,
+        pool_excess_lamports,
+    } = system;
+    let SystemAddresses {
+        mint,
+        holder_rewards_pool,
+    } = system_addresses;
+    let Holder {
+        token_account_balance: source_token_account_balance,
+        last_seen_total_rewards: source_last_seen_total_rewards,
+        unharvested_rewards: source_unharvested_rewards,
+        expected_unharvested_rewards: _,
+    } = source;
+    let HolderAddresses {
+        owner: source_owner,
+        token_account: source_token_account,
+        holder_rewards: source_holder_rewards,
+    } = source_addresses;
+    let Holder {
+        token_account_balance: destination_token_account_balance,
+        last_seen_total_rewards: destination_last_seen_total_rewards,
+        unharvested_rewards: destination_unharvested_rewards,
+        expected_unharvested_rewards: _,
+    } = destination;
+    let HolderAddresses {
+        owner: destination_owner,
+        token_account: destination_token_account,
+        holder_rewards: destination_holder_rewards,
+    } = destination_addresses;
+
+    setup_holder_rewards_pool_account(
+        context,
+        holder_rewards_pool,
+        *pool_excess_lamports,
+        *total_rewards,
+    )
+    .await;
+    setup_holder_rewards_account(
+        context,
+        source_holder_rewards,
+        *source_unharvested_rewards,
+        *source_last_seen_total_rewards,
+    )
+    .await;
+    setup_holder_rewards_account(
+        context,
+        destination_holder_rewards,
+        *destination_unharvested_rewards,
+        *destination_last_seen_total_rewards,
+    )
+    .await;
+    setup_token_account_transferring(
+        context,
+        source_token_account,
+        source_owner,
+        mint,
+        *source_token_account_balance - transfer_amount, // Post-transfer balance.
+    )
+    .await;
+    setup_token_account_transferring(
+        context,
+        destination_token_account,
+        destination_owner,
+        mint,
+        *destination_token_account_balance + transfer_amount, // Post-transfer balance.
+    )
+    .await;
+    setup_mint(context, mint, &Pubkey::new_unique(), *token_supply).await;
+}
+
+async fn setup_transfer_hook(
+    context: &mut ProgramTestContext,
+    system: &System,
+    system_addresses: &SystemAddresses,
+    source: &Holder,
+    source_addresses: &HolderAddresses,
+    destination: &Holder,
+    destination_addresses: &HolderAddresses,
+) {
+    let System {
+        token_supply,
+        total_rewards,
+        pool_excess_lamports,
+    } = system;
+    let SystemAddresses {
+        mint,
+        holder_rewards_pool,
+    } = system_addresses;
+    let Holder {
+        token_account_balance: source_token_account_balance,
+        last_seen_total_rewards: source_last_seen_total_rewards,
+        unharvested_rewards: source_unharvested_rewards,
+        expected_unharvested_rewards: _,
+    } = source;
+    let HolderAddresses {
+        owner: source_owner,
+        token_account: source_token_account,
+        holder_rewards: source_holder_rewards,
+    } = source_addresses;
+    let Holder {
+        token_account_balance: destination_token_account_balance,
+        last_seen_total_rewards: destination_last_seen_total_rewards,
+        unharvested_rewards: destination_unharvested_rewards,
+        expected_unharvested_rewards: _,
+    } = destination;
+    let HolderAddresses {
+        owner: destination_owner,
+        token_account: destination_token_account,
+        holder_rewards: destination_holder_rewards,
+    } = destination_addresses;
+
+    setup_extra_metas_account(context, mint).await;
+    setup_holder_rewards_pool_account(
+        context,
+        holder_rewards_pool,
+        *pool_excess_lamports,
+        *total_rewards,
+    )
+    .await;
+    setup_holder_rewards_account(
+        context,
+        source_holder_rewards,
+        *source_unharvested_rewards,
+        *source_last_seen_total_rewards,
+    )
+    .await;
+    setup_holder_rewards_account(
+        context,
+        destination_holder_rewards,
+        *destination_unharvested_rewards,
+        *destination_last_seen_total_rewards,
+    )
+    .await;
+    setup_token_account(
+        context,
+        source_token_account,
+        source_owner,
+        mint,
+        *source_token_account_balance,
+    )
+    .await;
+    setup_token_account(
+        context,
+        destination_token_account,
+        destination_owner,
+        mint,
+        *destination_token_account_balance,
+    )
+    .await;
+    setup_mint(context, mint, &Pubkey::new_unique(), *token_supply).await;
+}
+
+async fn check_holder_rewards(
+    context: &mut ProgramTestContext,
+    system: &System,
+    holder: &Holder,
+    holder_addresses: &HolderAddresses,
+) {
+    let holder_rewards_account = context
+        .banks_client
+        .get_account(holder_addresses.holder_rewards)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        bytemuck::from_bytes::<HolderRewards>(&holder_rewards_account.data),
+        &HolderRewards {
+            last_seen_total_rewards: system.total_rewards,
+            unharvested_rewards: holder.expected_unharvested_rewards,
+        },
+    );
+}
+
+#[test_case(
+    System {
+        token_supply: 0,
+        total_rewards: 0,
+        pool_excess_lamports: 0,
+    },
+    Holder {
+        token_account_balance: 0,
+        last_seen_total_rewards: 0,
+        unharvested_rewards: 0,
+        expected_unharvested_rewards: 0,
+    },
+    Holder {
+        token_account_balance: 0,
+        last_seen_total_rewards: 0,
+        unharvested_rewards: 0,
+        expected_unharvested_rewards: 0,
+    },
+    0;
+    "all zeroes, no rewards"
+)]
+// TODO: Add more tests once calculations are corrected.
+#[tokio::test]
+async fn success(system: System, source: Holder, destination: Holder, transfer_amount: u64) {
+    let source_owner = Keypair::new();
+    let destination_owner = Pubkey::new_unique();
+
+    let system_addresses = SystemAddresses::new();
+    let source_addresses = HolderAddresses::new(&source_owner.pubkey(), &system_addresses.mint);
+    let destination_addresses = HolderAddresses::new(&destination_owner, &system_addresses.mint);
+
+    // First test directly invoking the program.
+    {
+        let mut context = setup().start_with_context().await;
+        setup_direct_invoke(
+            &mut context,
+            &system,
+            &system_addresses,
+            &source,
+            &source_addresses,
+            &destination,
+            &destination_addresses,
+            transfer_amount,
+        )
+        .await;
+
+        let instruction = execute_with_extra_metas_instruction(
+            &source_addresses.token_account,
+            &system_addresses.mint,
+            &destination_addresses.token_account,
+            &source_addresses.owner,
+            &system_addresses.holder_rewards_pool,
+            &source_addresses.holder_rewards,
+            &destination_addresses.holder_rewards,
+            transfer_amount,
+        );
+
+        let transaction = Transaction::new_signed_with_payer(
+            &[instruction],
+            Some(&context.payer.pubkey()),
+            &[&context.payer],
+            context.last_blockhash,
+        );
+
+        context
+            .banks_client
+            .process_transaction(transaction)
+            .await
+            .unwrap();
+
+        check_holder_rewards(&mut context, &system, &source, &source_addresses).await;
+        check_holder_rewards(&mut context, &system, &destination, &destination_addresses).await;
+    }
+
+    // Then test transfer hook with Token-2022.
+    {
+        let mut context = setup().start_with_context().await;
+        setup_transfer_hook(
+            &mut context,
+            &system,
+            &system_addresses,
+            &source,
+            &source_addresses,
+            &destination,
+            &destination_addresses,
+        )
+        .await;
+
+        let instruction = transfer_with_extra_metas_instruction(
+            &mut context,
+            &source_addresses.token_account,
+            &system_addresses.mint,
+            &destination_addresses.token_account,
+            &source_addresses.owner,
+            transfer_amount,
+            0, // Decimals.
+        )
+        .await;
+
+        let transaction = Transaction::new_signed_with_payer(
+            &[instruction],
+            Some(&context.payer.pubkey()),
+            &[&context.payer, &source_owner],
+            context.last_blockhash,
+        );
+
+        context
+            .banks_client
+            .process_transaction(transaction)
+            .await
+            .unwrap();
+
+        check_holder_rewards(&mut context, &system, &source, &source_addresses).await;
+        check_holder_rewards(&mut context, &system, &destination, &destination_addresses).await;
+    }
+}


### PR DESCRIPTION
This PR introduces the processor for the SPL Transfer Hook interface's
`ExecuteInstruction` instruction.

Just like `HarvestRewards`, this instruction calculates each holder's share
of any unseen total rewards, this time updating their `unharvested_rewards`
and `last_seen_total_rewards` post-transfer.