### PR TITLE
Program: use `program_id` in PDA helpers

### DIFF
--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -87,7 +87,7 @@ fn check_pool(
     // address derived from the mint.
     if !holder_rewards_pool_info
         .key
-        .eq(&get_holder_rewards_pool_address(mint))
+        .eq(&get_holder_rewards_pool_address(mint, program_id))
     {
         return Err(PaladinRewardsError::IncorrectHolderRewardsPoolAddress.into());
     }
@@ -110,7 +110,7 @@ fn check_holder_rewards(
     // derived from the token account.
     if !holder_rewards_info
         .key
-        .eq(&get_holder_rewards_address(token_account_key))
+        .eq(&get_holder_rewards_address(token_account_key, program_id))
     {
         return Err(PaladinRewardsError::IncorrectHolderRewardsAddress.into());
     }
@@ -254,7 +254,7 @@ fn process_initialize_holder_rewards_pool(
     // Initialize the holder rewards pool account.
     {
         let (holder_rewards_pool_address, bump_seed) =
-            get_holder_rewards_pool_address_and_bump_seed(mint_info.key);
+            get_holder_rewards_pool_address_and_bump_seed(mint_info.key, program_id);
         let bump_seed = [bump_seed];
         let holder_rewards_pool_signer_seeds =
             collect_holder_rewards_pool_signer_seeds(mint_info.key, &bump_seed);
@@ -421,7 +421,7 @@ fn process_initialize_holder_rewards(
     // Initialize the holder rewards account.
     {
         let (holder_rewards_address, bump_seed) =
-            get_holder_rewards_address_and_bump_seed(token_account_info.key);
+            get_holder_rewards_address_and_bump_seed(token_account_info.key, program_id);
         let bump_seed = [bump_seed];
         let holder_rewards_signer_seeds =
             collect_holder_rewards_signer_seeds(token_account_info.key, &bump_seed);

--- a/program/src/state.rs
+++ b/program/src/state.rs
@@ -158,15 +158,18 @@ pub const SEED_PREFIX_HOLDER_REWARDS: &[u8] = b"holder";
 pub const SEED_PREFIX_HOLDER_REWARDS_POOL: &[u8] = b"holder_pool";
 
 /// Derive the address of a holder rewards account.
-pub fn get_holder_rewards_address(token_account_address: &Pubkey) -> Pubkey {
-    get_holder_rewards_address_and_bump_seed(token_account_address).0
+pub fn get_holder_rewards_address(token_account_address: &Pubkey, program_id: &Pubkey) -> Pubkey {
+    get_holder_rewards_address_and_bump_seed(token_account_address, program_id).0
 }
 
 /// Derive the address of a holder rewards account, with bump seed.
-pub fn get_holder_rewards_address_and_bump_seed(token_account_address: &Pubkey) -> (Pubkey, u8) {
+pub fn get_holder_rewards_address_and_bump_seed(
+    token_account_address: &Pubkey,
+    program_id: &Pubkey,
+) -> (Pubkey, u8) {
     Pubkey::find_program_address(
         &collect_holder_rewards_seeds(token_account_address),
-        &crate::id(),
+        program_id,
     )
 }
 
@@ -186,16 +189,16 @@ pub(crate) fn collect_holder_rewards_signer_seeds<'a>(
 }
 
 /// Derive the address of a holder rewards pool account.
-pub fn get_holder_rewards_pool_address(mint_address: &Pubkey) -> Pubkey {
-    get_holder_rewards_pool_address_and_bump_seed(mint_address).0
+pub fn get_holder_rewards_pool_address(mint_address: &Pubkey, program_id: &Pubkey) -> Pubkey {
+    get_holder_rewards_pool_address_and_bump_seed(mint_address, program_id).0
 }
 
 /// Derive the address of a holder rewards pool account, with bump seed.
-pub fn get_holder_rewards_pool_address_and_bump_seed(mint_address: &Pubkey) -> (Pubkey, u8) {
-    Pubkey::find_program_address(
-        &collect_holder_rewards_pool_seeds(mint_address),
-        &crate::id(),
-    )
+pub fn get_holder_rewards_pool_address_and_bump_seed(
+    mint_address: &Pubkey,
+    program_id: &Pubkey,
+) -> (Pubkey, u8) {
+    Pubkey::find_program_address(&collect_holder_rewards_pool_seeds(mint_address), program_id)
 }
 
 pub(crate) fn collect_holder_rewards_pool_seeds(mint_address: &Pubkey) -> [&[u8]; 2] {

--- a/program/tests/distribute_rewards.rs
+++ b/program/tests/distribute_rewards.rs
@@ -25,7 +25,8 @@ use {
 async fn fail_mint_invalid_data() {
     let mint = Pubkey::new_unique();
 
-    let holder_rewards_pool = get_holder_rewards_pool_address(&mint);
+    let holder_rewards_pool =
+        get_holder_rewards_pool_address(&mint, &paladin_rewards_program::id());
     let payer = Keypair::new();
     let amount = 500_000_000_000;
 
@@ -67,7 +68,8 @@ async fn fail_payer_not_signer() {
     let mint = Pubkey::new_unique();
     let token_supply = 100_000;
 
-    let holder_rewards_pool = get_holder_rewards_pool_address(&mint);
+    let holder_rewards_pool =
+        get_holder_rewards_pool_address(&mint, &paladin_rewards_program::id());
     let payer = Keypair::new();
     let amount = 500_000_000_000;
 
@@ -102,7 +104,8 @@ async fn fail_holder_rewards_pool_incorrect_owner() {
     let mint = Pubkey::new_unique();
     let token_supply = 100_000;
 
-    let holder_rewards_pool = get_holder_rewards_pool_address(&mint);
+    let holder_rewards_pool =
+        get_holder_rewards_pool_address(&mint, &paladin_rewards_program::id());
     let payer = Keypair::new();
     let amount = 500_000_000_000;
 
@@ -188,7 +191,8 @@ async fn fail_holder_rewards_pool_invalid_data() {
     let mint = Pubkey::new_unique();
     let token_supply = 100_000;
 
-    let holder_rewards_pool = get_holder_rewards_pool_address(&mint);
+    let holder_rewards_pool =
+        get_holder_rewards_pool_address(&mint, &paladin_rewards_program::id());
     let payer = Keypair::new();
     let amount = 500_000_000_000;
 
@@ -341,7 +345,8 @@ async fn success(initial: InitialPool, expected: ExpectedPool, reward_amount: u6
 
     let mint = Pubkey::new_unique();
 
-    let holder_rewards_pool = get_holder_rewards_pool_address(&mint);
+    let holder_rewards_pool =
+        get_holder_rewards_pool_address(&mint, &paladin_rewards_program::id());
     let payer = Keypair::new();
 
     let mut context = setup().start_with_context().await;

--- a/program/tests/harvest_rewards.rs
+++ b/program/tests/harvest_rewards.rs
@@ -30,8 +30,9 @@ async fn fail_token_account_invalid_data() {
     let mint = Pubkey::new_unique();
 
     let token_account = get_associated_token_address(&owner, &mint);
-    let holder_rewards = get_holder_rewards_address(&token_account);
-    let holder_rewards_pool = get_holder_rewards_pool_address(&mint);
+    let holder_rewards = get_holder_rewards_address(&token_account, &paladin_rewards_program::id());
+    let holder_rewards_pool =
+        get_holder_rewards_pool_address(&mint, &paladin_rewards_program::id());
 
     let mut context = setup().start_with_context().await;
 
@@ -72,8 +73,9 @@ async fn fail_token_account_mint_mismatch() {
     let mint = Pubkey::new_unique();
 
     let token_account = get_associated_token_address(&owner, &mint);
-    let holder_rewards = get_holder_rewards_address(&token_account);
-    let holder_rewards_pool = get_holder_rewards_pool_address(&mint);
+    let holder_rewards = get_holder_rewards_address(&token_account, &paladin_rewards_program::id());
+    let holder_rewards_pool =
+        get_holder_rewards_pool_address(&mint, &paladin_rewards_program::id());
 
     let mut context = setup().start_with_context().await;
     setup_token_account(
@@ -116,8 +118,9 @@ async fn fail_holder_rewards_pool_incorrect_owner() {
     let mint = Pubkey::new_unique();
 
     let token_account = get_associated_token_address(&owner, &mint);
-    let holder_rewards = get_holder_rewards_address(&token_account);
-    let holder_rewards_pool = get_holder_rewards_pool_address(&mint);
+    let holder_rewards = get_holder_rewards_address(&token_account, &paladin_rewards_program::id());
+    let holder_rewards_pool =
+        get_holder_rewards_pool_address(&mint, &paladin_rewards_program::id());
 
     let mut context = setup().start_with_context().await;
     setup_holder_rewards_account(&mut context, &holder_rewards, 0, 0).await;
@@ -159,7 +162,7 @@ async fn fail_holder_rewards_pool_incorrect_address() {
     let mint = Pubkey::new_unique();
 
     let token_account = get_associated_token_address(&owner, &mint);
-    let holder_rewards = get_holder_rewards_address(&token_account);
+    let holder_rewards = get_holder_rewards_address(&token_account, &paladin_rewards_program::id());
     let holder_rewards_pool = Pubkey::new_unique(); // Incorrect holder rewards pool address.
 
     let mut context = setup().start_with_context().await;
@@ -198,8 +201,9 @@ async fn fail_holder_rewards_pool_invalid_data() {
     let mint = Pubkey::new_unique();
 
     let token_account = get_associated_token_address(&owner, &mint);
-    let holder_rewards = get_holder_rewards_address(&token_account);
-    let holder_rewards_pool = get_holder_rewards_pool_address(&mint);
+    let holder_rewards = get_holder_rewards_address(&token_account, &paladin_rewards_program::id());
+    let holder_rewards_pool =
+        get_holder_rewards_pool_address(&mint, &paladin_rewards_program::id());
 
     let mut context = setup().start_with_context().await;
     setup_token_account(&mut context, &token_account, &owner, &mint, 0).await;
@@ -245,8 +249,9 @@ async fn fail_holder_rewards_incorrect_owner() {
     let mint = Pubkey::new_unique();
 
     let token_account = get_associated_token_address(&owner, &mint);
-    let holder_rewards = get_holder_rewards_address(&token_account);
-    let holder_rewards_pool = get_holder_rewards_pool_address(&mint);
+    let holder_rewards = get_holder_rewards_address(&token_account, &paladin_rewards_program::id());
+    let holder_rewards_pool =
+        get_holder_rewards_pool_address(&mint, &paladin_rewards_program::id());
 
     let mut context = setup().start_with_context().await;
     setup_holder_rewards_pool_account(&mut context, &holder_rewards_pool, 0, 0).await;
@@ -289,7 +294,8 @@ async fn fail_holder_rewards_incorrect_address() {
 
     let token_account = get_associated_token_address(&owner, &mint);
     let holder_rewards = Pubkey::new_unique(); // Incorrect holder rewards address.
-    let holder_rewards_pool = get_holder_rewards_pool_address(&mint);
+    let holder_rewards_pool =
+        get_holder_rewards_pool_address(&mint, &paladin_rewards_program::id());
 
     let mut context = setup().start_with_context().await;
     setup_holder_rewards_pool_account(&mut context, &holder_rewards_pool, 0, 0).await;
@@ -327,8 +333,9 @@ async fn fail_holder_rewards_invalid_data() {
     let mint = Pubkey::new_unique();
 
     let token_account = get_associated_token_address(&owner, &mint);
-    let holder_rewards = get_holder_rewards_address(&token_account);
-    let holder_rewards_pool = get_holder_rewards_pool_address(&mint);
+    let holder_rewards = get_holder_rewards_address(&token_account, &paladin_rewards_program::id());
+    let holder_rewards_pool =
+        get_holder_rewards_pool_address(&mint, &paladin_rewards_program::id());
 
     let mut context = setup().start_with_context().await;
     setup_holder_rewards_pool_account(&mut context, &holder_rewards_pool, 0, 0).await;
@@ -570,8 +577,9 @@ async fn success(
     let mint = Pubkey::new_unique();
 
     let token_account = get_associated_token_address(&owner, &mint);
-    let holder_rewards = get_holder_rewards_address(&token_account);
-    let holder_rewards_pool = get_holder_rewards_pool_address(&mint);
+    let holder_rewards = get_holder_rewards_address(&token_account, &paladin_rewards_program::id());
+    let holder_rewards_pool =
+        get_holder_rewards_pool_address(&mint, &paladin_rewards_program::id());
 
     let mut context = setup().start_with_context().await;
     setup_holder_rewards_pool_account(

--- a/program/tests/initialize_holder_rewards.rs
+++ b/program/tests/initialize_holder_rewards.rs
@@ -27,8 +27,9 @@ async fn fail_token_account_invalid_data() {
     let mint = Pubkey::new_unique();
 
     let token_account = get_associated_token_address(&owner, &mint);
-    let holder_rewards = get_holder_rewards_address(&token_account);
-    let holder_rewards_pool = get_holder_rewards_pool_address(&mint);
+    let holder_rewards = get_holder_rewards_address(&token_account, &paladin_rewards_program::id());
+    let holder_rewards_pool =
+        get_holder_rewards_pool_address(&mint, &paladin_rewards_program::id());
 
     let mut context = setup().start_with_context().await;
     setup_mint(&mut context, &mint, &Pubkey::new_unique(), 0).await;
@@ -71,8 +72,9 @@ async fn fail_token_account_mint_mismatch() {
     let mint = Pubkey::new_unique();
 
     let token_account = get_associated_token_address(&owner, &mint);
-    let holder_rewards = get_holder_rewards_address(&token_account);
-    let holder_rewards_pool = get_holder_rewards_pool_address(&mint);
+    let holder_rewards = get_holder_rewards_address(&token_account, &paladin_rewards_program::id());
+    let holder_rewards_pool =
+        get_holder_rewards_pool_address(&mint, &paladin_rewards_program::id());
 
     let mut context = setup().start_with_context().await;
     setup_token_account(
@@ -117,8 +119,9 @@ async fn fail_holder_rewards_pool_incorrect_owner() {
     let mint = Pubkey::new_unique();
 
     let token_account = get_associated_token_address(&owner, &mint);
-    let holder_rewards = get_holder_rewards_address(&token_account);
-    let holder_rewards_pool = get_holder_rewards_pool_address(&mint);
+    let holder_rewards = get_holder_rewards_address(&token_account, &paladin_rewards_program::id());
+    let holder_rewards_pool =
+        get_holder_rewards_pool_address(&mint, &paladin_rewards_program::id());
 
     let mut context = setup().start_with_context().await;
     setup_token_account(&mut context, &token_account, &owner, &mint, 0).await;
@@ -161,7 +164,7 @@ async fn fail_holder_rewards_pool_incorrect_address() {
     let mint = Pubkey::new_unique();
 
     let token_account = get_associated_token_address(&owner, &mint);
-    let holder_rewards = get_holder_rewards_address(&token_account);
+    let holder_rewards = get_holder_rewards_address(&token_account, &paladin_rewards_program::id());
     let holder_rewards_pool = Pubkey::new_unique(); // Incorrect holder rewards pool address.
 
     let mut context = setup().start_with_context().await;
@@ -201,8 +204,9 @@ async fn fail_holder_rewards_pool_invalid_data() {
     let mint = Pubkey::new_unique();
 
     let token_account = get_associated_token_address(&owner, &mint);
-    let holder_rewards = get_holder_rewards_address(&token_account);
-    let holder_rewards_pool = get_holder_rewards_pool_address(&mint);
+    let holder_rewards = get_holder_rewards_address(&token_account, &paladin_rewards_program::id());
+    let holder_rewards_pool =
+        get_holder_rewards_pool_address(&mint, &paladin_rewards_program::id());
 
     let mut context = setup().start_with_context().await;
     setup_token_account(&mut context, &token_account, &owner, &mint, 0).await;
@@ -251,7 +255,8 @@ async fn fail_holder_rewards_incorrect_address() {
 
     let token_account = get_associated_token_address(&owner, &mint);
     let holder_rewards = Pubkey::new_unique(); // Incorrect holder reward address.
-    let holder_rewards_pool = get_holder_rewards_pool_address(&mint);
+    let holder_rewards_pool =
+        get_holder_rewards_pool_address(&mint, &paladin_rewards_program::id());
 
     let mut context = setup().start_with_context().await;
     setup_holder_rewards_pool_account(&mut context, &holder_rewards_pool, 0, 0).await;
@@ -290,8 +295,9 @@ async fn fail_holder_rewards_account_initialized() {
     let mint = Pubkey::new_unique();
 
     let token_account = get_associated_token_address(&owner, &mint);
-    let holder_rewards = get_holder_rewards_address(&token_account);
-    let holder_rewards_pool = get_holder_rewards_pool_address(&mint);
+    let holder_rewards = get_holder_rewards_address(&token_account, &paladin_rewards_program::id());
+    let holder_rewards_pool =
+        get_holder_rewards_pool_address(&mint, &paladin_rewards_program::id());
 
     let mut context = setup().start_with_context().await;
     setup_holder_rewards_pool_account(&mut context, &holder_rewards_pool, 0, 0).await;
@@ -344,8 +350,9 @@ async fn success() {
     let mint = Pubkey::new_unique();
 
     let token_account = get_associated_token_address(&owner, &mint);
-    let holder_rewards = get_holder_rewards_address(&token_account);
-    let holder_rewards_pool = get_holder_rewards_pool_address(&mint);
+    let holder_rewards = get_holder_rewards_address(&token_account, &paladin_rewards_program::id());
+    let holder_rewards_pool =
+        get_holder_rewards_pool_address(&mint, &paladin_rewards_program::id());
 
     let mut context = setup().start_with_context().await;
     setup_holder_rewards_pool_account(

--- a/program/tests/initialize_holder_rewards_pool.rs
+++ b/program/tests/initialize_holder_rewards_pool.rs
@@ -41,7 +41,8 @@ async fn fail_mint_invalid_data() {
     let mint = Pubkey::new_unique();
     let mint_authority = Keypair::new();
 
-    let holder_rewards_pool = get_holder_rewards_pool_address(&mint);
+    let holder_rewards_pool =
+        get_holder_rewards_pool_address(&mint, &paladin_rewards_program::id());
     let extra_metas = get_extra_account_metas_address(&mint, &paladin_rewards_program::id());
 
     let mut context = setup().start_with_context().await;
@@ -87,7 +88,8 @@ async fn fail_mint_missing_transfer_hook_extension() {
     let mint = Pubkey::new_unique();
     let mint_authority = Keypair::new();
 
-    let holder_rewards_pool = get_holder_rewards_pool_address(&mint);
+    let holder_rewards_pool =
+        get_holder_rewards_pool_address(&mint, &paladin_rewards_program::id());
     let extra_metas = get_extra_account_metas_address(&mint, &paladin_rewards_program::id());
 
     let mut context = setup().start_with_context().await;
@@ -153,7 +155,8 @@ async fn fail_mint_incorrect_transfer_hook_program_id() {
     let mint = Pubkey::new_unique();
     let mint_authority = Keypair::new();
 
-    let holder_rewards_pool = get_holder_rewards_pool_address(&mint);
+    let holder_rewards_pool =
+        get_holder_rewards_pool_address(&mint, &paladin_rewards_program::id());
     let extra_metas = get_extra_account_metas_address(&mint, &paladin_rewards_program::id());
 
     let mut context = setup().start_with_context().await;
@@ -226,7 +229,8 @@ async fn fail_incorrect_mint_authority() {
     let mint = Pubkey::new_unique();
     let mint_authority = Keypair::new();
 
-    let holder_rewards_pool = get_holder_rewards_pool_address(&mint);
+    let holder_rewards_pool =
+        get_holder_rewards_pool_address(&mint, &paladin_rewards_program::id());
     let extra_metas = get_extra_account_metas_address(&mint, &paladin_rewards_program::id());
 
     let mut context = setup().start_with_context().await;
@@ -277,7 +281,8 @@ async fn fail_mint_authority_not_signer() {
     let mint = Pubkey::new_unique();
     let mint_authority = Keypair::new();
 
-    let holder_rewards_pool = get_holder_rewards_pool_address(&mint);
+    let holder_rewards_pool =
+        get_holder_rewards_pool_address(&mint, &paladin_rewards_program::id());
     let extra_metas = get_extra_account_metas_address(&mint, &paladin_rewards_program::id());
 
     let mut context = setup().start_with_context().await;
@@ -357,7 +362,8 @@ async fn fail_holder_rewards_pool_account_initialized() {
     let mint = Pubkey::new_unique();
     let mint_authority = Keypair::new();
 
-    let holder_rewards_pool = get_holder_rewards_pool_address(&mint);
+    let holder_rewards_pool =
+        get_holder_rewards_pool_address(&mint, &paladin_rewards_program::id());
     let extra_metas = get_extra_account_metas_address(&mint, &paladin_rewards_program::id());
 
     let mut context = setup().start_with_context().await;
@@ -408,7 +414,8 @@ async fn fail_extra_metas_incorrect_address() {
     let mint = Pubkey::new_unique();
     let mint_authority = Keypair::new();
 
-    let holder_rewards_pool = get_holder_rewards_pool_address(&mint);
+    let holder_rewards_pool =
+        get_holder_rewards_pool_address(&mint, &paladin_rewards_program::id());
     let extra_metas = Pubkey::new_unique(); // Incorrect extra metas address.
 
     let mut context = setup().start_with_context().await;
@@ -449,7 +456,8 @@ async fn fail_extra_metas_account_initialized() {
     let mint = Pubkey::new_unique();
     let mint_authority = Keypair::new();
 
-    let holder_rewards_pool = get_holder_rewards_pool_address(&mint);
+    let holder_rewards_pool =
+        get_holder_rewards_pool_address(&mint, &paladin_rewards_program::id());
     let extra_metas = get_extra_account_metas_address(&mint, &paladin_rewards_program::id());
 
     let mut context = setup().start_with_context().await;
@@ -500,7 +508,8 @@ async fn success() {
     let mint = Pubkey::new_unique();
     let mint_authority = Keypair::new();
 
-    let holder_rewards_pool = get_holder_rewards_pool_address(&mint);
+    let holder_rewards_pool =
+        get_holder_rewards_pool_address(&mint, &paladin_rewards_program::id());
     let extra_metas = get_extra_account_metas_address(&mint, &paladin_rewards_program::id());
 
     let mut context = setup().start_with_context().await;

--- a/program/tests/transfer_hook.rs
+++ b/program/tests/transfer_hook.rs
@@ -118,15 +118,18 @@ async fn transfer_with_extra_metas_instruction(
 #[tokio::test]
 async fn fail_holder_rewards_pool_incorrect_owner() {
     let mint = Pubkey::new_unique();
-    let holder_rewards_pool = get_holder_rewards_pool_address(&mint);
+    let holder_rewards_pool =
+        get_holder_rewards_pool_address(&mint, &paladin_rewards_program::id());
 
     let source_owner = Keypair::new();
     let source_token_account = get_associated_token_address(&source_owner.pubkey(), &mint);
-    let source_holder_rewards = get_holder_rewards_address(&source_token_account);
+    let source_holder_rewards =
+        get_holder_rewards_address(&source_token_account, &paladin_rewards_program::id());
 
     let destination_owner = Pubkey::new_unique();
     let destination_token_account = get_associated_token_address(&destination_owner, &mint);
-    let destination_holder_rewards = get_holder_rewards_address(&destination_token_account);
+    let destination_holder_rewards =
+        get_holder_rewards_address(&destination_token_account, &paladin_rewards_program::id());
 
     let mut context = setup().start_with_context().await;
 
@@ -176,11 +179,13 @@ async fn fail_holder_rewards_pool_incorrect_address() {
 
     let source_owner = Keypair::new();
     let source_token_account = get_associated_token_address(&source_owner.pubkey(), &mint);
-    let source_holder_rewards = get_holder_rewards_address(&source_token_account);
+    let source_holder_rewards =
+        get_holder_rewards_address(&source_token_account, &paladin_rewards_program::id());
 
     let destination_owner = Pubkey::new_unique();
     let destination_token_account = get_associated_token_address(&destination_owner, &mint);
-    let destination_holder_rewards = get_holder_rewards_address(&destination_token_account);
+    let destination_holder_rewards =
+        get_holder_rewards_address(&destination_token_account, &paladin_rewards_program::id());
 
     let mut context = setup().start_with_context().await;
     setup_holder_rewards_pool_account(&mut context, &holder_rewards_pool, 0, 0).await;
@@ -222,15 +227,18 @@ async fn fail_holder_rewards_pool_incorrect_address() {
 #[tokio::test]
 async fn fail_holder_rewards_pool_invalid_data() {
     let mint = Pubkey::new_unique();
-    let holder_rewards_pool = get_holder_rewards_pool_address(&mint);
+    let holder_rewards_pool =
+        get_holder_rewards_pool_address(&mint, &paladin_rewards_program::id());
 
     let source_owner = Keypair::new();
     let source_token_account = get_associated_token_address(&source_owner.pubkey(), &mint);
-    let source_holder_rewards = get_holder_rewards_address(&source_token_account);
+    let source_holder_rewards =
+        get_holder_rewards_address(&source_token_account, &paladin_rewards_program::id());
 
     let destination_owner = Pubkey::new_unique();
     let destination_token_account = get_associated_token_address(&destination_owner, &mint);
-    let destination_holder_rewards = get_holder_rewards_address(&destination_token_account);
+    let destination_holder_rewards =
+        get_holder_rewards_address(&destination_token_account, &paladin_rewards_program::id());
 
     let mut context = setup().start_with_context().await;
 
@@ -277,7 +285,8 @@ async fn fail_holder_rewards_pool_invalid_data() {
 #[tokio::test]
 async fn fail_source_holder_rewards_incorrect_address() {
     let mint = Pubkey::new_unique();
-    let holder_rewards_pool = get_holder_rewards_pool_address(&mint);
+    let holder_rewards_pool =
+        get_holder_rewards_pool_address(&mint, &paladin_rewards_program::id());
 
     let source_owner = Keypair::new();
     let source_token_account = get_associated_token_address(&source_owner.pubkey(), &mint);
@@ -285,7 +294,8 @@ async fn fail_source_holder_rewards_incorrect_address() {
 
     let destination_owner = Pubkey::new_unique();
     let destination_token_account = get_associated_token_address(&destination_owner, &mint);
-    let destination_holder_rewards = get_holder_rewards_address(&destination_token_account);
+    let destination_holder_rewards =
+        get_holder_rewards_address(&destination_token_account, &paladin_rewards_program::id());
 
     let mut context = setup().start_with_context().await;
     setup_holder_rewards_pool_account(&mut context, &holder_rewards_pool, 0, 0).await;
@@ -328,15 +338,18 @@ async fn fail_source_holder_rewards_incorrect_address() {
 #[tokio::test]
 async fn fail_source_holder_rewards_invalid_data() {
     let mint = Pubkey::new_unique();
-    let holder_rewards_pool = get_holder_rewards_pool_address(&mint);
+    let holder_rewards_pool =
+        get_holder_rewards_pool_address(&mint, &paladin_rewards_program::id());
 
     let source_owner = Keypair::new();
     let source_token_account = get_associated_token_address(&source_owner.pubkey(), &mint);
-    let source_holder_rewards = get_holder_rewards_address(&source_token_account);
+    let source_holder_rewards =
+        get_holder_rewards_address(&source_token_account, &paladin_rewards_program::id());
 
     let destination_owner = Pubkey::new_unique();
     let destination_token_account = get_associated_token_address(&destination_owner, &mint);
-    let destination_holder_rewards = get_holder_rewards_address(&destination_token_account);
+    let destination_holder_rewards =
+        get_holder_rewards_address(&destination_token_account, &paladin_rewards_program::id());
 
     let mut context = setup().start_with_context().await;
     setup_holder_rewards_pool_account(&mut context, &holder_rewards_pool, 0, 0).await;
@@ -385,15 +398,18 @@ async fn fail_source_holder_rewards_invalid_data() {
 #[tokio::test]
 async fn fail_source_token_account_invalid_data() {
     let mint = Pubkey::new_unique();
-    let holder_rewards_pool = get_holder_rewards_pool_address(&mint);
+    let holder_rewards_pool =
+        get_holder_rewards_pool_address(&mint, &paladin_rewards_program::id());
 
     let source_owner = Keypair::new();
     let source_token_account = get_associated_token_address(&source_owner.pubkey(), &mint);
-    let source_holder_rewards = get_holder_rewards_address(&source_token_account);
+    let source_holder_rewards =
+        get_holder_rewards_address(&source_token_account, &paladin_rewards_program::id());
 
     let destination_owner = Pubkey::new_unique();
     let destination_token_account = get_associated_token_address(&destination_owner, &mint);
-    let destination_holder_rewards = get_holder_rewards_address(&destination_token_account);
+    let destination_holder_rewards =
+        get_holder_rewards_address(&destination_token_account, &paladin_rewards_program::id());
 
     let mut context = setup().start_with_context().await;
     setup_holder_rewards_pool_account(&mut context, &holder_rewards_pool, 0, 0).await;
@@ -442,15 +458,18 @@ async fn fail_source_token_account_invalid_data() {
 #[tokio::test]
 async fn fail_source_token_account_mint_mismatch() {
     let mint = Pubkey::new_unique();
-    let holder_rewards_pool = get_holder_rewards_pool_address(&mint);
+    let holder_rewards_pool =
+        get_holder_rewards_pool_address(&mint, &paladin_rewards_program::id());
 
     let source_owner = Keypair::new();
     let source_token_account = get_associated_token_address(&source_owner.pubkey(), &mint);
-    let source_holder_rewards = get_holder_rewards_address(&source_token_account);
+    let source_holder_rewards =
+        get_holder_rewards_address(&source_token_account, &paladin_rewards_program::id());
 
     let destination_owner = Pubkey::new_unique();
     let destination_token_account = get_associated_token_address(&destination_owner, &mint);
-    let destination_holder_rewards = get_holder_rewards_address(&destination_token_account);
+    let destination_holder_rewards =
+        get_holder_rewards_address(&destination_token_account, &paladin_rewards_program::id());
 
     let mut context = setup().start_with_context().await;
     setup_holder_rewards_pool_account(&mut context, &holder_rewards_pool, 0, 0).await;
@@ -501,15 +520,18 @@ async fn fail_source_token_account_mint_mismatch() {
 #[tokio::test]
 async fn fail_source_token_account_not_transferring() {
     let mint = Pubkey::new_unique();
-    let holder_rewards_pool = get_holder_rewards_pool_address(&mint);
+    let holder_rewards_pool =
+        get_holder_rewards_pool_address(&mint, &paladin_rewards_program::id());
 
     let source_owner = Keypair::new();
     let source_token_account = get_associated_token_address(&source_owner.pubkey(), &mint);
-    let source_holder_rewards = get_holder_rewards_address(&source_token_account);
+    let source_holder_rewards =
+        get_holder_rewards_address(&source_token_account, &paladin_rewards_program::id());
 
     let destination_owner = Pubkey::new_unique();
     let destination_token_account = get_associated_token_address(&destination_owner, &mint);
-    let destination_holder_rewards = get_holder_rewards_address(&destination_token_account);
+    let destination_holder_rewards =
+        get_holder_rewards_address(&destination_token_account, &paladin_rewards_program::id());
 
     let mut context = setup().start_with_context().await;
     setup_holder_rewards_pool_account(&mut context, &holder_rewards_pool, 0, 0).await;
@@ -561,11 +583,13 @@ async fn fail_source_token_account_not_transferring() {
 #[tokio::test]
 async fn fail_destination_holder_rewards_incorrect_address() {
     let mint = Pubkey::new_unique();
-    let holder_rewards_pool = get_holder_rewards_pool_address(&mint);
+    let holder_rewards_pool =
+        get_holder_rewards_pool_address(&mint, &paladin_rewards_program::id());
 
     let source_owner = Keypair::new();
     let source_token_account = get_associated_token_address(&source_owner.pubkey(), &mint);
-    let source_holder_rewards = get_holder_rewards_address(&source_token_account);
+    let source_holder_rewards =
+        get_holder_rewards_address(&source_token_account, &paladin_rewards_program::id());
 
     let destination_owner = Pubkey::new_unique();
     let destination_token_account = get_associated_token_address(&destination_owner, &mint);
@@ -621,15 +645,18 @@ async fn fail_destination_holder_rewards_incorrect_address() {
 #[tokio::test]
 async fn fail_destination_holder_rewards_invalid_data() {
     let mint = Pubkey::new_unique();
-    let holder_rewards_pool = get_holder_rewards_pool_address(&mint);
+    let holder_rewards_pool =
+        get_holder_rewards_pool_address(&mint, &paladin_rewards_program::id());
 
     let source_owner = Keypair::new();
     let source_token_account = get_associated_token_address(&source_owner.pubkey(), &mint);
-    let source_holder_rewards = get_holder_rewards_address(&source_token_account);
+    let source_holder_rewards =
+        get_holder_rewards_address(&source_token_account, &paladin_rewards_program::id());
 
     let destination_owner = Pubkey::new_unique();
     let destination_token_account = get_associated_token_address(&destination_owner, &mint);
-    let destination_holder_rewards = get_holder_rewards_address(&destination_token_account);
+    let destination_holder_rewards =
+        get_holder_rewards_address(&destination_token_account, &paladin_rewards_program::id());
 
     let mut context = setup().start_with_context().await;
     setup_holder_rewards_pool_account(&mut context, &holder_rewards_pool, 0, 0).await;
@@ -686,15 +713,18 @@ async fn fail_destination_holder_rewards_invalid_data() {
 #[tokio::test]
 async fn fail_destination_token_account_invalid_data() {
     let mint = Pubkey::new_unique();
-    let holder_rewards_pool = get_holder_rewards_pool_address(&mint);
+    let holder_rewards_pool =
+        get_holder_rewards_pool_address(&mint, &paladin_rewards_program::id());
 
     let source_owner = Keypair::new();
     let source_token_account = get_associated_token_address(&source_owner.pubkey(), &mint);
-    let source_holder_rewards = get_holder_rewards_address(&source_token_account);
+    let source_holder_rewards =
+        get_holder_rewards_address(&source_token_account, &paladin_rewards_program::id());
 
     let destination_owner = Pubkey::new_unique();
     let destination_token_account = get_associated_token_address(&destination_owner, &mint);
-    let destination_holder_rewards = get_holder_rewards_address(&destination_token_account);
+    let destination_holder_rewards =
+        get_holder_rewards_address(&destination_token_account, &paladin_rewards_program::id());
 
     let mut context = setup().start_with_context().await;
     setup_holder_rewards_pool_account(&mut context, &holder_rewards_pool, 0, 0).await;
@@ -752,15 +782,18 @@ async fn fail_destination_token_account_invalid_data() {
 #[tokio::test]
 async fn fail_destination_token_account_mint_mismatch() {
     let mint = Pubkey::new_unique();
-    let holder_rewards_pool = get_holder_rewards_pool_address(&mint);
+    let holder_rewards_pool =
+        get_holder_rewards_pool_address(&mint, &paladin_rewards_program::id());
 
     let source_owner = Keypair::new();
     let source_token_account = get_associated_token_address(&source_owner.pubkey(), &mint);
-    let source_holder_rewards = get_holder_rewards_address(&source_token_account);
+    let source_holder_rewards =
+        get_holder_rewards_address(&source_token_account, &paladin_rewards_program::id());
 
     let destination_owner = Pubkey::new_unique();
     let destination_token_account = get_associated_token_address(&destination_owner, &mint);
-    let destination_holder_rewards = get_holder_rewards_address(&destination_token_account);
+    let destination_holder_rewards =
+        get_holder_rewards_address(&destination_token_account, &paladin_rewards_program::id());
 
     let mut context = setup().start_with_context().await;
     setup_holder_rewards_pool_account(&mut context, &holder_rewards_pool, 0, 0).await;
@@ -820,15 +853,18 @@ async fn fail_destination_token_account_mint_mismatch() {
 #[tokio::test]
 async fn fail_destination_token_account_not_transferring() {
     let mint = Pubkey::new_unique();
-    let holder_rewards_pool = get_holder_rewards_pool_address(&mint);
+    let holder_rewards_pool =
+        get_holder_rewards_pool_address(&mint, &paladin_rewards_program::id());
 
     let source_owner = Keypair::new();
     let source_token_account = get_associated_token_address(&source_owner.pubkey(), &mint);
-    let source_holder_rewards = get_holder_rewards_address(&source_token_account);
+    let source_holder_rewards =
+        get_holder_rewards_address(&source_token_account, &paladin_rewards_program::id());
 
     let destination_owner = Pubkey::new_unique();
     let destination_token_account = get_associated_token_address(&destination_owner, &mint);
-    let destination_holder_rewards = get_holder_rewards_address(&destination_token_account);
+    let destination_holder_rewards =
+        get_holder_rewards_address(&destination_token_account, &paladin_rewards_program::id());
 
     let mut context = setup().start_with_context().await;
     setup_holder_rewards_pool_account(&mut context, &holder_rewards_pool, 0, 0).await;
@@ -898,7 +934,8 @@ struct PoolAddresses {
 impl PoolAddresses {
     fn new() -> Self {
         let mint = Pubkey::new_unique();
-        let holder_rewards_pool = get_holder_rewards_pool_address(&mint);
+        let holder_rewards_pool =
+            get_holder_rewards_pool_address(&mint, &paladin_rewards_program::id());
         Self {
             mint,
             holder_rewards_pool,
@@ -922,7 +959,8 @@ struct HolderAddresses {
 impl HolderAddresses {
     fn new(owner: &Pubkey, mint: &Pubkey) -> Self {
         let token_account = get_associated_token_address(owner, mint);
-        let holder_rewards = get_holder_rewards_address(&token_account);
+        let holder_rewards =
+            get_holder_rewards_address(&token_account, &paladin_rewards_program::id());
         Self {
             owner: *owner,
             token_account,


### PR DESCRIPTION
This PR updates the PDA helpers...

- `get_holder_rewards_address`
- `get_holder_rewards_pool_address`

... to take a `program_id` as input.