### PR TITLE
Update program to use "rewards per token" calculation

### DIFF
--- a/clients/js/src/generated/accounts/holderRewards.ts
+++ b/clients/js/src/generated/accounts/holderRewards.ts
@@ -33,29 +33,29 @@ import {
 
 export type HolderRewards = {
   lastRewardsPerToken: bigint;
-  lastSeenTotalRewards: bigint;
   unharvestedRewards: bigint;
+  padding: bigint;
 };
 
 export type HolderRewardsArgs = {
   lastRewardsPerToken: number | bigint;
-  lastSeenTotalRewards: number | bigint;
   unharvestedRewards: number | bigint;
+  padding: number | bigint;
 };
 
 export function getHolderRewardsEncoder(): Encoder<HolderRewardsArgs> {
   return getStructEncoder([
     ['lastRewardsPerToken', getU128Encoder()],
-    ['lastSeenTotalRewards', getU64Encoder()],
     ['unharvestedRewards', getU64Encoder()],
+    ['padding', getU64Encoder()],
   ]);
 }
 
 export function getHolderRewardsDecoder(): Decoder<HolderRewards> {
   return getStructDecoder([
     ['lastRewardsPerToken', getU128Decoder()],
-    ['lastSeenTotalRewards', getU64Decoder()],
     ['unharvestedRewards', getU64Decoder()],
+    ['padding', getU64Decoder()],
   ]);
 }
 

--- a/clients/js/src/generated/accounts/holderRewards.ts
+++ b/clients/js/src/generated/accounts/holderRewards.ts
@@ -15,6 +15,8 @@ import {
   fetchEncodedAccounts,
   getStructDecoder,
   getStructEncoder,
+  getU128Decoder,
+  getU128Encoder,
   getU64Decoder,
   getU64Encoder,
   type Account,
@@ -30,17 +32,20 @@ import {
 } from '@solana/web3.js';
 
 export type HolderRewards = {
+  lastRewardsPerToken: bigint;
   lastSeenTotalRewards: bigint;
   unharvestedRewards: bigint;
 };
 
 export type HolderRewardsArgs = {
+  lastRewardsPerToken: number | bigint;
   lastSeenTotalRewards: number | bigint;
   unharvestedRewards: number | bigint;
 };
 
 export function getHolderRewardsEncoder(): Encoder<HolderRewardsArgs> {
   return getStructEncoder([
+    ['lastRewardsPerToken', getU128Encoder()],
     ['lastSeenTotalRewards', getU64Encoder()],
     ['unharvestedRewards', getU64Encoder()],
   ]);
@@ -48,6 +53,7 @@ export function getHolderRewardsEncoder(): Encoder<HolderRewardsArgs> {
 
 export function getHolderRewardsDecoder(): Decoder<HolderRewards> {
   return getStructDecoder([
+    ['lastRewardsPerToken', getU128Decoder()],
     ['lastSeenTotalRewards', getU64Decoder()],
     ['unharvestedRewards', getU64Decoder()],
   ]);
@@ -118,5 +124,5 @@ export async function fetchAllMaybeHolderRewards(
 }
 
 export function getHolderRewardsSize(): number {
-  return 16;
+  return 32;
 }

--- a/clients/js/src/generated/accounts/holderRewards.ts
+++ b/clients/js/src/generated/accounts/holderRewards.ts
@@ -32,20 +32,20 @@ import {
 } from '@solana/web3.js';
 
 export type HolderRewards = {
-  lastRewardsPerToken: bigint;
+  lastAccumulatedRewardsPerToken: bigint;
   unharvestedRewards: bigint;
   padding: bigint;
 };
 
 export type HolderRewardsArgs = {
-  lastRewardsPerToken: number | bigint;
+  lastAccumulatedRewardsPerToken: number | bigint;
   unharvestedRewards: number | bigint;
   padding: number | bigint;
 };
 
 export function getHolderRewardsEncoder(): Encoder<HolderRewardsArgs> {
   return getStructEncoder([
-    ['lastRewardsPerToken', getU128Encoder()],
+    ['lastAccumulatedRewardsPerToken', getU128Encoder()],
     ['unharvestedRewards', getU64Encoder()],
     ['padding', getU64Encoder()],
   ]);
@@ -53,7 +53,7 @@ export function getHolderRewardsEncoder(): Encoder<HolderRewardsArgs> {
 
 export function getHolderRewardsDecoder(): Decoder<HolderRewards> {
   return getStructDecoder([
-    ['lastRewardsPerToken', getU128Decoder()],
+    ['lastAccumulatedRewardsPerToken', getU128Decoder()],
     ['unharvestedRewards', getU64Decoder()],
     ['padding', getU64Decoder()],
   ]);

--- a/clients/js/src/generated/accounts/holderRewardsPool.ts
+++ b/clients/js/src/generated/accounts/holderRewardsPool.ts
@@ -17,8 +17,6 @@ import {
   getStructEncoder,
   getU128Decoder,
   getU128Encoder,
-  getU64Decoder,
-  getU64Encoder,
   type Account,
   type Address,
   type Codec,
@@ -31,32 +29,16 @@ import {
   type MaybeEncodedAccount,
 } from '@solana/web3.js';
 
-export type HolderRewardsPool = {
-  rewardsPerToken: bigint;
-  totalRewards: bigint;
-  padding: bigint;
-};
+export type HolderRewardsPool = { rewardsPerToken: bigint };
 
-export type HolderRewardsPoolArgs = {
-  rewardsPerToken: number | bigint;
-  totalRewards: number | bigint;
-  padding: number | bigint;
-};
+export type HolderRewardsPoolArgs = { rewardsPerToken: number | bigint };
 
 export function getHolderRewardsPoolEncoder(): Encoder<HolderRewardsPoolArgs> {
-  return getStructEncoder([
-    ['rewardsPerToken', getU128Encoder()],
-    ['totalRewards', getU64Encoder()],
-    ['padding', getU64Encoder()],
-  ]);
+  return getStructEncoder([['rewardsPerToken', getU128Encoder()]]);
 }
 
 export function getHolderRewardsPoolDecoder(): Decoder<HolderRewardsPool> {
-  return getStructDecoder([
-    ['rewardsPerToken', getU128Decoder()],
-    ['totalRewards', getU64Decoder()],
-    ['padding', getU64Decoder()],
-  ]);
+  return getStructDecoder([['rewardsPerToken', getU128Decoder()]]);
 }
 
 export function getHolderRewardsPoolCodec(): Codec<
@@ -133,5 +115,5 @@ export async function fetchAllMaybeHolderRewardsPool(
 }
 
 export function getHolderRewardsPoolSize(): number {
-  return 32;
+  return 16;
 }

--- a/clients/js/src/generated/accounts/holderRewardsPool.ts
+++ b/clients/js/src/generated/accounts/holderRewardsPool.ts
@@ -29,16 +29,18 @@ import {
   type MaybeEncodedAccount,
 } from '@solana/web3.js';
 
-export type HolderRewardsPool = { rewardsPerToken: bigint };
+export type HolderRewardsPool = { accumulatedRewardsPerToken: bigint };
 
-export type HolderRewardsPoolArgs = { rewardsPerToken: number | bigint };
+export type HolderRewardsPoolArgs = {
+  accumulatedRewardsPerToken: number | bigint;
+};
 
 export function getHolderRewardsPoolEncoder(): Encoder<HolderRewardsPoolArgs> {
-  return getStructEncoder([['rewardsPerToken', getU128Encoder()]]);
+  return getStructEncoder([['accumulatedRewardsPerToken', getU128Encoder()]]);
 }
 
 export function getHolderRewardsPoolDecoder(): Decoder<HolderRewardsPool> {
-  return getStructDecoder([['rewardsPerToken', getU128Decoder()]]);
+  return getStructDecoder([['accumulatedRewardsPerToken', getU128Decoder()]]);
 }
 
 export function getHolderRewardsPoolCodec(): Codec<

--- a/clients/js/src/generated/accounts/holderRewardsPool.ts
+++ b/clients/js/src/generated/accounts/holderRewardsPool.ts
@@ -15,6 +15,8 @@ import {
   fetchEncodedAccounts,
   getStructDecoder,
   getStructEncoder,
+  getU128Decoder,
+  getU128Encoder,
   getU64Decoder,
   getU64Encoder,
   type Account,
@@ -29,16 +31,32 @@ import {
   type MaybeEncodedAccount,
 } from '@solana/web3.js';
 
-export type HolderRewardsPool = { totalRewards: bigint };
+export type HolderRewardsPool = {
+  rewardsPerToken: bigint;
+  totalRewards: bigint;
+  padding: bigint;
+};
 
-export type HolderRewardsPoolArgs = { totalRewards: number | bigint };
+export type HolderRewardsPoolArgs = {
+  rewardsPerToken: number | bigint;
+  totalRewards: number | bigint;
+  padding: number | bigint;
+};
 
 export function getHolderRewardsPoolEncoder(): Encoder<HolderRewardsPoolArgs> {
-  return getStructEncoder([['totalRewards', getU64Encoder()]]);
+  return getStructEncoder([
+    ['rewardsPerToken', getU128Encoder()],
+    ['totalRewards', getU64Encoder()],
+    ['padding', getU64Encoder()],
+  ]);
 }
 
 export function getHolderRewardsPoolDecoder(): Decoder<HolderRewardsPool> {
-  return getStructDecoder([['totalRewards', getU64Decoder()]]);
+  return getStructDecoder([
+    ['rewardsPerToken', getU128Decoder()],
+    ['totalRewards', getU64Decoder()],
+    ['padding', getU64Decoder()],
+  ]);
 }
 
 export function getHolderRewardsPoolCodec(): Codec<
@@ -115,5 +133,5 @@ export async function fetchAllMaybeHolderRewardsPool(
 }
 
 export function getHolderRewardsPoolSize(): number {
-  return 8;
+  return 32;
 }

--- a/clients/rust/src/generated/accounts/holder_rewards.rs
+++ b/clients/rust/src/generated/accounts/holder_rewards.rs
@@ -9,7 +9,7 @@ use borsh::{BorshDeserialize, BorshSerialize};
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct HolderRewards {
-    pub last_rewards_per_token: u128,
+    pub last_accumulated_rewards_per_token: u128,
     pub unharvested_rewards: u64,
     pub padding: u64,
 }

--- a/clients/rust/src/generated/accounts/holder_rewards.rs
+++ b/clients/rust/src/generated/accounts/holder_rewards.rs
@@ -9,12 +9,13 @@ use borsh::{BorshDeserialize, BorshSerialize};
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct HolderRewards {
+    pub last_rewards_per_token: u128,
     pub last_seen_total_rewards: u64,
     pub unharvested_rewards: u64,
 }
 
 impl HolderRewards {
-    pub const LEN: usize = 16;
+    pub const LEN: usize = 32;
 
     #[inline(always)]
     pub fn from_bytes(data: &[u8]) -> Result<Self, std::io::Error> {

--- a/clients/rust/src/generated/accounts/holder_rewards.rs
+++ b/clients/rust/src/generated/accounts/holder_rewards.rs
@@ -10,8 +10,8 @@ use borsh::{BorshDeserialize, BorshSerialize};
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct HolderRewards {
     pub last_rewards_per_token: u128,
-    pub last_seen_total_rewards: u64,
     pub unharvested_rewards: u64,
+    pub padding: u64,
 }
 
 impl HolderRewards {

--- a/clients/rust/src/generated/accounts/holder_rewards_pool.rs
+++ b/clients/rust/src/generated/accounts/holder_rewards_pool.rs
@@ -9,7 +9,7 @@ use borsh::{BorshDeserialize, BorshSerialize};
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct HolderRewardsPool {
-    pub rewards_per_token: u128,
+    pub accumulated_rewards_per_token: u128,
 }
 
 impl HolderRewardsPool {

--- a/clients/rust/src/generated/accounts/holder_rewards_pool.rs
+++ b/clients/rust/src/generated/accounts/holder_rewards_pool.rs
@@ -9,11 +9,13 @@ use borsh::{BorshDeserialize, BorshSerialize};
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct HolderRewardsPool {
+    pub rewards_per_token: u128,
     pub total_rewards: u64,
+    pub padding: u64,
 }
 
 impl HolderRewardsPool {
-    pub const LEN: usize = 8;
+    pub const LEN: usize = 32;
 
     #[inline(always)]
     pub fn from_bytes(data: &[u8]) -> Result<Self, std::io::Error> {

--- a/clients/rust/src/generated/accounts/holder_rewards_pool.rs
+++ b/clients/rust/src/generated/accounts/holder_rewards_pool.rs
@@ -10,12 +10,10 @@ use borsh::{BorshDeserialize, BorshSerialize};
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct HolderRewardsPool {
     pub rewards_per_token: u128,
-    pub total_rewards: u64,
-    pub padding: u64,
 }
 
 impl HolderRewardsPool {
-    pub const LEN: usize = 32;
+    pub const LEN: usize = 16;
 
     #[inline(always)]
     pub fn from_bytes(data: &[u8]) -> Result<Self, std::io::Error> {

--- a/program/idl.json
+++ b/program/idl.json
@@ -199,7 +199,7 @@
         "kind": "struct",
         "fields": [
           {
-            "name": "lastRewardsPerToken",
+            "name": "lastAccumulatedRewardsPerToken",
             "type": "u128"
           },
           {
@@ -219,7 +219,7 @@
         "kind": "struct",
         "fields": [
           {
-            "name": "rewardsPerToken",
+            "name": "accumulatedRewardsPerToken",
             "type": "u128"
           }
         ]

--- a/program/idl.json
+++ b/program/idl.json
@@ -72,6 +72,14 @@
           ]
         },
         {
+          "name": "mint",
+          "isMut": false,
+          "isSigner": false,
+          "docs": [
+            "Token mint."
+          ]
+        },
+        {
           "name": "systemProgram",
           "isMut": false,
           "isSigner": false,
@@ -191,6 +199,10 @@
         "kind": "struct",
         "fields": [
           {
+            "name": "lastRewardsPerToken",
+            "type": "u128"
+          },
+          {
             "name": "lastSeenTotalRewards",
             "type": "u64"
           },
@@ -207,7 +219,15 @@
         "kind": "struct",
         "fields": [
           {
+            "name": "rewardsPerToken",
+            "type": "u128"
+          },
+          {
             "name": "totalRewards",
+            "type": "u64"
+          },
+          {
+            "name": "padding",
             "type": "u64"
           }
         ]

--- a/program/idl.json
+++ b/program/idl.json
@@ -203,11 +203,11 @@
             "type": "u128"
           },
           {
-            "name": "lastSeenTotalRewards",
+            "name": "unharvestedRewards",
             "type": "u64"
           },
           {
-            "name": "unharvestedRewards",
+            "name": "padding",
             "type": "u64"
           }
         ]
@@ -221,14 +221,6 @@
           {
             "name": "rewardsPerToken",
             "type": "u128"
-          },
-          {
-            "name": "totalRewards",
-            "type": "u64"
-          },
-          {
-            "name": "padding",
-            "type": "u64"
           }
         ]
       }

--- a/program/src/error.rs
+++ b/program/src/error.rs
@@ -23,4 +23,7 @@ pub enum PaladinRewardsError {
     /// Token account mint mismatch.
     #[error("Token account mint mismatch")]
     TokenAccountMintMismatch,
+    /// Holder has no rewards to harvest.
+    #[error("Holder has no rewards to harvest")]
+    NoRewardsToHarvest,
 }

--- a/program/src/error.rs
+++ b/program/src/error.rs
@@ -23,7 +23,4 @@ pub enum PaladinRewardsError {
     /// Token account mint mismatch.
     #[error("Token account mint mismatch")]
     TokenAccountMintMismatch,
-    /// Holder has no rewards to harvest.
-    #[error("Holder has no rewards to harvest")]
-    NoRewardsToHarvest,
 }

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -64,7 +64,8 @@ pub enum PaladinRewardsInstruction {
     ///
     /// 0. `[w, s]` Payer account.
     /// 1. `[w]` Holder rewards pool account.
-    /// 2. `[ ]` System program.
+    /// 2. `[ ]` Token mint.
+    /// 3. `[ ]` System program.
     #[account(
         0,
         writable,
@@ -80,6 +81,11 @@ pub enum PaladinRewardsInstruction {
     )]
     #[account(
         2,
+        name = "mint",
+        desc = "Token mint.",
+    )]
+    #[account(
+        3,
         name = "system_program",
         desc = "System program.",
     )]
@@ -222,11 +228,13 @@ pub fn initialize_holder_rewards_pool(
 pub fn distribute_rewards(
     payer_address: &Pubkey,
     holder_rewards_pool_address: &Pubkey,
+    mint: &Pubkey,
     amount: u64,
 ) -> Instruction {
     let accounts = vec![
         AccountMeta::new(*payer_address, true),
         AccountMeta::new(*holder_rewards_pool_address, false),
+        AccountMeta::new_readonly(*mint, false),
         AccountMeta::new_readonly(system_program::id(), false),
     ];
     let data = PaladinRewardsInstruction::DistributeRewards(amount).pack();

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -101,8 +101,9 @@ fn calculate_eligible_rewards(
 ) -> Result<u64, ProgramError> {
     // Calculation: (current_accumulated_rewards_per_token
     //   - last_accumulated_rewards_per_token) * token_account_balance
-    let marginal_rate =
-        current_accumulated_rewards_per_token.saturating_sub(last_accumulated_rewards_per_token);
+    let marginal_rate = current_accumulated_rewards_per_token
+        .checked_sub(last_accumulated_rewards_per_token)
+        .ok_or(ProgramError::ArithmeticOverflow)?;
     if marginal_rate == 0 {
         return Ok(0);
     }

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -427,6 +427,10 @@ fn process_harvest_rewards(program_id: &Pubkey, accounts: &[AccountInfo]) -> Pro
     )?;
     let rewards_to_harvest = eligible_rewards.min(pool_excess_lamports);
 
+    if rewards_to_harvest == 0 {
+        return Err(PaladinRewardsError::NoRewardsToHarvest.into());
+    }
+
     // Move the amount from the holder rewards pool to the token account.
     let new_holder_rewards_pool_lamports = holder_rewards_pool_info
         .lamports()

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -92,22 +92,22 @@ fn calculate_rewards_per_token(rewards: u64, token_supply: u64) -> Result<u128, 
         .ok_or(ProgramError::ArithmeticOverflow)
 }
 
-fn calculate_reward_share(
-    token_supply: u64,
+fn calculate_eligible_rewards(
+    current_rewards_per_token: u128,
+    last_rewards_per_token: u128,
     token_account_balance: u64,
-    total_rewards: u64,
 ) -> Result<u64, ProgramError> {
-    if token_supply == 0 {
+    // Calculation: (current_rewards_per_token - last_rewards_per_token) *
+    // token_account_balance
+    let marginal_rate = current_rewards_per_token.saturating_sub(last_rewards_per_token);
+    if marginal_rate == 0 {
         return Ok(0);
     }
-    // Calculation: (token_amount / total_token_supply) * pool_rewards
-    //
-    // However, multiplication is done first to avoid truncation, ie:
-    // (token_amount * pool_rewards) / total_token_supply
-    (token_account_balance as u128)
-        .checked_mul(total_rewards as u128)
-        .and_then(|product| product.checked_div(token_supply as u128))
-        .and_then(|share| u64::try_from(share).ok())
+    // Scaled by 1e9 to store 9 decimal places of precision.
+    marginal_rate
+        .checked_mul(token_account_balance as u128)
+        .and_then(|product| product.checked_div(1_000_000_000))
+        .and_then(|product| product.try_into().ok())
         .ok_or(ProgramError::ArithmeticOverflow)
 }
 
@@ -384,8 +384,7 @@ fn process_harvest_rewards(program_id: &Pubkey, accounts: &[AccountInfo]) -> Pro
     let token_account_info = next_account_info(accounts_iter)?;
     let mint_info = next_account_info(accounts_iter)?;
 
-    let token_supply = get_token_supply(mint_info)?;
-
+    // Run checks on the token account.
     let token_account_balance =
         get_token_account_balance_checked(mint_info.key, token_account_info)?;
 
@@ -393,7 +392,6 @@ fn process_harvest_rewards(program_id: &Pubkey, accounts: &[AccountInfo]) -> Pro
     let pool_data = holder_rewards_pool_info.try_borrow_data()?;
     let pool_state = bytemuck::try_from_bytes::<HolderRewardsPool>(&pool_data)
         .map_err(|_| ProgramError::InvalidAccountData)?;
-    let current_total_rewards = pool_state.total_rewards;
 
     // Ensure the holder rewards account is owned by the Paladin Rewards
     // program.
@@ -415,49 +413,27 @@ fn process_harvest_rewards(program_id: &Pubkey, accounts: &[AccountInfo]) -> Pro
         bytemuck::try_from_bytes_mut::<HolderRewards>(&mut holder_rewards_data)
             .map_err(|_| ProgramError::InvalidAccountData)?;
 
-    // Update the holder rewards state with the new "last seen" total rewards.
-    let last_seen_total_rewards = std::mem::replace(
-        &mut holder_rewards_state.last_seen_total_rewards,
-        current_total_rewards,
-    );
-
-    // Calculate unharvested rewards for the token account.
-    // Since the holder rewards account may already have unharvested rewards,
-    // calculate the share of rewards that have not been seen by the holder
-    // rewards account.
-    let rewards_to_harvest = {
-        // Rewards accrued by the system that haven't been seen by the holder.
-        let unseen_total_rewards = current_total_rewards
-            .checked_sub(last_seen_total_rewards)
-            .ok_or(ProgramError::ArithmeticOverflow)?;
-
-        // The holder's share of the unseen rewards.
-        let unseen_unharvested_rewards =
-            calculate_reward_share(token_supply, token_account_balance, unseen_total_rewards)?;
-
-        // The total unharvested rewards the holder is eligible to claim.
-        let total_eligible_rewards = holder_rewards_state
-            .unharvested_rewards
-            .checked_add(unseen_unharvested_rewards)
-            .ok_or(ProgramError::ArithmeticOverflow)?;
-
-        // Temporarily update unharvested rewards to reflect total eligible
-        // rewards. This will be re-adjusted post-harvest.
-        holder_rewards_state.unharvested_rewards = total_eligible_rewards;
-
-        // Make sure the pool can't be overdrawn by harvesting.
+    // Determine the amount the holder can harvest.
+    //
+    // This is done by subtracting the `last_rewards_per_token` rate from the
+    // pool's current rate, then multiplying by the token account balance.
+    //
+    // If the pool doesn't have enough lamports to cover the rewards, only
+    // harvest the available lamports. This should never happen, but the check
+    // is a failsafe.
+    let pool_excess_lamports = {
         let rent = <Rent as Sysvar>::get()?;
         let rent_exempt_lamports = rent.minimum_balance(std::mem::size_of::<HolderRewardsPool>());
-
-        // If the pool doesn't have enough lamports to cover the rewards, only
-        // harvest the available lamports.
-        total_eligible_rewards.min(
-            holder_rewards_pool_info
-                .lamports()
-                .checked_sub(rent_exempt_lamports)
-                .ok_or(ProgramError::ArithmeticOverflow)?,
-        )
+        holder_rewards_pool_info
+            .lamports()
+            .saturating_sub(rent_exempt_lamports)
     };
+    let eligible_rewards = calculate_eligible_rewards(
+        pool_state.rewards_per_token,
+        holder_rewards_state.last_rewards_per_token,
+        token_account_balance,
+    )?;
+    let rewards_to_harvest = eligible_rewards.min(pool_excess_lamports);
 
     // Move the amount from the holder rewards pool to the token account.
     let new_holder_rewards_pool_lamports = holder_rewards_pool_info
@@ -471,10 +447,10 @@ fn process_harvest_rewards(program_id: &Pubkey, accounts: &[AccountInfo]) -> Pro
     **holder_rewards_pool_info.try_borrow_mut_lamports()? = new_holder_rewards_pool_lamports;
     **token_account_info.try_borrow_mut_lamports()? = new_token_account_lamports;
 
-    // Update the holder rewards state with the new "unharvested" rewards.
-    holder_rewards_state.unharvested_rewards = holder_rewards_state
-        .unharvested_rewards
-        .saturating_sub(rewards_to_harvest);
+    // Update the holder rewards state.
+    holder_rewards_state.last_rewards_per_token = pool_state.rewards_per_token;
+    holder_rewards_state.last_seen_total_rewards = pool_state.total_rewards;
+    holder_rewards_state.unharvested_rewards = eligible_rewards.saturating_sub(rewards_to_harvest);
 
     Ok(())
 }

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -35,6 +35,8 @@ use {
     },
 };
 
+const REWARDS_PER_TOKEN_SCALING_FACTOR: u128 = 1_000_000_000; // 1e9
+
 fn get_token_supply(mint_info: &AccountInfo) -> Result<u64, ProgramError> {
     let mint_data = mint_info.try_borrow_data()?;
     let mint = StateWithExtensions::<Mint>::unpack(&mint_data)?;
@@ -87,7 +89,7 @@ fn calculate_rewards_per_token(rewards: u64, token_supply: u64) -> Result<u128, 
     //
     // Scaled by 1e9 to store 9 decimal places of precision.
     (rewards as u128)
-        .checked_mul(1_000_000_000)
+        .checked_mul(REWARDS_PER_TOKEN_SCALING_FACTOR)
         .and_then(|product| product.checked_div(token_supply as u128))
         .ok_or(ProgramError::ArithmeticOverflow)
 }
@@ -106,7 +108,7 @@ fn calculate_eligible_rewards(
     // Scaled by 1e9 to store 9 decimal places of precision.
     marginal_rate
         .checked_mul(token_account_balance as u128)
-        .and_then(|product| product.checked_div(1_000_000_000))
+        .and_then(|product| product.checked_div(REWARDS_PER_TOKEN_SCALING_FACTOR))
         .and_then(|product| product.try_into().ok())
         .ok_or(ProgramError::ArithmeticOverflow)
 }

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -357,6 +357,7 @@ fn process_initialize_holder_rewards(
         let mut data = holder_rewards_info.try_borrow_mut_data()?;
         *bytemuck::try_from_bytes_mut(&mut data).map_err(|_| ProgramError::InvalidAccountData)? =
             HolderRewards {
+                last_rewards_per_token: pool_state.rewards_per_token,
                 last_seen_total_rewards: pool_state.total_rewards,
                 unharvested_rewards,
             };

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -56,11 +56,11 @@ fn get_token_account_balance_checked(
     Ok(token_account.base.amount)
 }
 
-fn get_total_rewards_checked(
+fn check_pool(
     program_id: &Pubkey,
     mint: &Pubkey,
     holder_rewards_pool_info: &AccountInfo,
-) -> Result<u64, ProgramError> {
+) -> ProgramResult {
     // Ensure the holder rewards pool is owned by the Paladin Rewards
     // program.
     if !holder_rewards_pool_info.owner.eq(program_id) {
@@ -76,12 +76,7 @@ fn get_total_rewards_checked(
         return Err(PaladinRewardsError::IncorrectHolderRewardsPoolAddress.into());
     }
 
-    let holder_rewards_pool_data = holder_rewards_pool_info.try_borrow_data()?;
-    let holder_rewards_pool_state =
-        bytemuck::try_from_bytes::<HolderRewardsPool>(&holder_rewards_pool_data)
-            .map_err(|_| ProgramError::InvalidAccountData)?;
-
-    Ok(holder_rewards_pool_state.total_rewards)
+    Ok(())
 }
 
 fn calculate_reward_share(
@@ -298,8 +293,10 @@ fn process_initialize_holder_rewards(
     let token_account_balance =
         get_token_account_balance_checked(mint_info.key, token_account_info)?;
 
-    let last_seen_total_rewards =
-        get_total_rewards_checked(program_id, mint_info.key, holder_rewards_pool_info)?;
+    check_pool(program_id, mint_info.key, holder_rewards_pool_info)?;
+    let pool_data = holder_rewards_pool_info.try_borrow_data()?;
+    let pool_state = bytemuck::try_from_bytes::<HolderRewardsPool>(&pool_data)
+        .map_err(|_| ProgramError::InvalidAccountData)?;
 
     // Calculate unharvested rewards for the token account.
     //
@@ -361,7 +358,7 @@ fn process_initialize_holder_rewards(
         let mut data = holder_rewards_info.try_borrow_mut_data()?;
         *bytemuck::try_from_bytes_mut(&mut data).map_err(|_| ProgramError::InvalidAccountData)? =
             HolderRewards {
-                last_seen_total_rewards,
+                last_seen_total_rewards: pool_state.total_rewards,
                 unharvested_rewards,
             };
     }
@@ -384,8 +381,11 @@ fn process_harvest_rewards(program_id: &Pubkey, accounts: &[AccountInfo]) -> Pro
     let token_account_balance =
         get_token_account_balance_checked(mint_info.key, token_account_info)?;
 
-    let current_total_rewards =
-        get_total_rewards_checked(program_id, mint_info.key, holder_rewards_pool_info)?;
+    check_pool(program_id, mint_info.key, holder_rewards_pool_info)?;
+    let pool_data = holder_rewards_pool_info.try_borrow_data()?;
+    let pool_state = bytemuck::try_from_bytes::<HolderRewardsPool>(&pool_data)
+        .map_err(|_| ProgramError::InvalidAccountData)?;
+    let current_total_rewards = pool_state.total_rewards;
 
     // Ensure the holder rewards account is owned by the Paladin Rewards
     // program.

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -238,6 +238,7 @@ fn process_distribute_rewards(
 
     let payer_info = next_account_info(accounts_iter)?;
     let holder_rewards_pool_info = next_account_info(accounts_iter)?;
+    let mint_info = next_account_info(accounts_iter)?;
     let _system_program_info = next_account_info(accounts_iter)?;
 
     // Ensure the payer account is a signer.
@@ -245,11 +246,9 @@ fn process_distribute_rewards(
         return Err(ProgramError::MissingRequiredSignature);
     }
 
-    // Ensure the holder rewards pool account is owned by the Paladin Rewards
-    // program.
-    if !holder_rewards_pool_info.owner.eq(program_id) {
-        return Err(ProgramError::InvalidAccountOwner);
-    }
+    let _token_supply = get_token_supply(mint_info)?;
+
+    check_pool(program_id, mint_info.key, holder_rewards_pool_info)?;
 
     // Update the total rewards in the holder rewards pool.
     {

--- a/program/src/state.rs
+++ b/program/src/state.rs
@@ -19,12 +19,9 @@
 //! Consider the following scenario.
 //!
 //! ```text
-//!
+//! 
 //! -- Legend --
 //!
-//!     `total_rewards`:        The running counter of total rewards accrued by
-//!                             the system, as stored in the pool's account
-//!                             state.
 //!     `rewards_per_share`:    Total rewards / token supply.
 //!     `available_rewards:`    The number of lamports that can be withdrawn
 //!                             from the pool without going below the
@@ -34,9 +31,9 @@
 //! --
 //!
 //! Pool:   token_supply:       100         Alice:  last_seen_rate:     0
-//!         total_rewards:      100                 token_balance:      25
-//!         rewards_per_token:  1                   eligible_for:       25
-//!         available_rewards:  100
+//!         rewards_per_token:  1                   token_balance:      25
+//!         available_rewards:  100                 eligible_for:       25
+//!
 //!                                         Bob:    last_seen_rate:     0
 //!                                                 token_balance:      40
 //!                                                 eligible_for:       40
@@ -52,9 +49,9 @@
 //! are deposited into the pool.
 //!
 //! Pool:   token_supply:       125         Alice:  last_seen_rate:     0
-//!         total_rewards:      100                 token_balance:      25
-//!         rewards_per_token:  1                   eligible_for:       25
-//!         available_rewards:  100
+//!         rewards_per_token:  1                   token_balance:      25
+//!         available_rewards:  100                 eligible_for:       25
+//!
 //!                                         Bob:    last_seen_rate:     0
 //!                                                 token_balance:      40
 //!                                                 eligible_for:       40
@@ -72,9 +69,9 @@
 //! The rewards per token rate is stored in Bob's holder account state.
 //!
 //! Pool:   token_supply:       125         Alice:  last_seen_rate:     0
-//!         total_rewards:      100                 token_balance:      25
-//!         rewards_per_token:  1                   eligible_for:       25
-//!         available_rewards:  60
+//!         rewards_per_token:  1                   token_balance:      25
+//!         available_rewards:  60                  eligible_for:       25
+//!
 //!                                         Bob:    last_seen_rate:     1
 //!                                                 token_balance:      40
 //!                                                 eligible_for:       0
@@ -94,9 +91,9 @@
 //! can still claim rewards at the old rate.
 //!
 //! Pool:   token_supply:       100         Alice:  last_seen_rate:     1
-//!         total_rewards:      100                 token_balance:      0
-//!         rewards_per_token:  1                   eligible_for:       0
-//!         available_rewards:  35
+//!         rewards_per_token:  1                   token_balance:      0
+//!         available_rewards:  35                  eligible_for:       0
+//!
 //!                                         Bob:    last_seen_rate:     1
 //!                                                 token_balance:      40
 //!                                                 eligible_for:       0
@@ -126,9 +123,9 @@
 //! He's eligible for (3 - 1) * 25 = 50 rewards.
 //!
 //! Pool:   token_supply:       100         Alice:  last_seen_rate:     1
-//!         total_rewards:      300                 token_balance:      0
-//!         rewards_per_token:  3                   eligible_for:       0
-//!         available_rewards:  235
+//!         rewards_per_token:  3                   token_balance:      0
+//!         available_rewards:  235                 eligible_for:       0
+//!
 //!                                         Bob:    last_seen_rate:     1
 //!                                                 token_balance:      40
 //!                                                 eligible_for:       80
@@ -143,7 +140,6 @@
 //!
 //! Now the total unharvested claims is 80 + 105 + 50 = 235, which is exactly
 //! what's availabe in the pool.
-//!
 //! ```
 
 use {
@@ -227,12 +223,19 @@ pub struct HolderRewards {
     /// Stored as a `u128`, which includes a scaling factor of `1e9` to
     /// represent the exchange rate with 9 decimal places of precision.
     pub last_rewards_per_token: u128,
-    /// The last seen total rewards amount in the aggregate holder rewards
-    /// account.
-    pub last_seen_total_rewards: u64,
     /// The amount of unharvested rewards currently stored in the holder
     /// rewards account that can be harvested by the holder.
     pub unharvested_rewards: u64,
+    _padding: u64,
+}
+impl HolderRewards {
+    pub fn new(last_rewards_per_token: u128, unharvested_rewards: u64) -> Self {
+        Self {
+            last_rewards_per_token,
+            unharvested_rewards,
+            _padding: 0,
+        }
+    }
 }
 
 /// Tracks the rewards accumulated by the system and manages the distribution
@@ -247,16 +250,4 @@ pub struct HolderRewardsPool {
     /// Stored as a `u128`, which includes a scaling factor of `1e9` to
     /// represent the exchange rate with 9 decimal places of precision.
     pub rewards_per_token: u128,
-    /// Total holder rewards available for distribution.
-    pub total_rewards: u64,
-    _padding: u64,
-}
-impl HolderRewardsPool {
-    pub fn new(rewards_per_token: u128, total_rewards: u64) -> Self {
-        Self {
-            rewards_per_token,
-            total_rewards,
-            _padding: 0,
-        }
-    }
 }

--- a/program/src/state.rs
+++ b/program/src/state.rs
@@ -222,16 +222,16 @@ pub struct HolderRewards {
     ///
     /// Stored as a `u128`, which includes a scaling factor of `1e9` to
     /// represent the exchange rate with 9 decimal places of precision.
-    pub last_rewards_per_token: u128,
+    pub last_accumulated_rewards_per_token: u128,
     /// The amount of unharvested rewards currently stored in the holder
     /// rewards account that can be harvested by the holder.
     pub unharvested_rewards: u64,
     _padding: u64,
 }
 impl HolderRewards {
-    pub fn new(last_rewards_per_token: u128, unharvested_rewards: u64) -> Self {
+    pub fn new(last_accumulated_rewards_per_token: u128, unharvested_rewards: u64) -> Self {
         Self {
-            last_rewards_per_token,
+            last_accumulated_rewards_per_token,
             unharvested_rewards,
             _padding: 0,
         }
@@ -249,5 +249,5 @@ pub struct HolderRewardsPool {
     ///
     /// Stored as a `u128`, which includes a scaling factor of `1e9` to
     /// represent the exchange rate with 9 decimal places of precision.
-    pub rewards_per_token: u128,
+    pub accumulated_rewards_per_token: u128,
 }

--- a/program/tests/distribute_rewards.rs
+++ b/program/tests/distribute_rewards.rs
@@ -154,7 +154,7 @@ async fn fail_holder_rewards_pool_invalid_address() {
     let amount = 500_000_000_000;
 
     let mut context = setup().start_with_context().await;
-    setup_holder_rewards_pool_account(&mut context, &holder_rewards_pool, 0, 0).await;
+    setup_holder_rewards_pool_account(&mut context, &holder_rewards_pool, 0, 0, 0).await;
     setup_mint(&mut context, &mint, &Pubkey::new_unique(), token_supply).await;
 
     let instruction = distribute_rewards(&payer.pubkey(), &holder_rewards_pool, &mint, amount);
@@ -242,7 +242,7 @@ async fn success() {
 
     let mut context = setup().start_with_context().await;
     setup_system_account(&mut context, &payer.pubkey(), amount).await;
-    setup_holder_rewards_pool_account(&mut context, &holder_rewards_pool, 0, 0).await;
+    setup_holder_rewards_pool_account(&mut context, &holder_rewards_pool, 0, 0, 0).await;
     setup_mint(&mut context, &mint, &Pubkey::new_unique(), token_supply).await;
 
     // For checks later.
@@ -278,9 +278,7 @@ async fn success() {
         .unwrap();
     assert_eq!(
         bytemuck::from_bytes::<HolderRewardsPool>(&holder_rewards_pool_account.data),
-        &HolderRewardsPool {
-            total_rewards: amount
-        }
+        &HolderRewardsPool::new(0, amount),
     );
 
     // Assert the pool was debited lamports.

--- a/program/tests/distribute_rewards.rs
+++ b/program/tests/distribute_rewards.rs
@@ -233,21 +233,21 @@ async fn fail_holder_rewards_pool_invalid_data() {
 
 struct InitialPool {
     token_supply: u64,
-    rewards_per_token: u128,
+    accumulated_rewards_per_token: u128,
 }
 
 struct ExpectedPool {
-    rewards_per_token: u128,
+    accumulated_rewards_per_token: u128,
 }
 
 #[allow(clippy::arithmetic_side_effects)]
 #[test_case(
     InitialPool {
         token_supply: 0,
-        rewards_per_token: 0,
+        accumulated_rewards_per_token: 0,
     },
     ExpectedPool {
-        rewards_per_token: 0,
+        accumulated_rewards_per_token: 0,
     },
     100_000;
     "Zero token supply, zero rewards per token, increment total rewards"
@@ -255,10 +255,10 @@ struct ExpectedPool {
 #[test_case(
     InitialPool {
         token_supply: 100_000,
-        rewards_per_token: 0,
+        accumulated_rewards_per_token: 0,
     },
     ExpectedPool {
-        rewards_per_token: 2_500_000_000, // 0% + 250_000 / 100_000 = 250%
+        accumulated_rewards_per_token: 2_500_000_000, // 0% + 250_000 / 100_000 = 250%
     },
     250_000;
     "Zero initial rate and rewards, resulting rate 250%"
@@ -266,10 +266,10 @@ struct ExpectedPool {
 #[test_case(
     InitialPool {
         token_supply: 1_000_000,
-        rewards_per_token: 0,
+        accumulated_rewards_per_token: 0,
     },
     ExpectedPool {
-        rewards_per_token: 100_000_000, // 0% + 100_000 / 1_000_000 = 10%
+        accumulated_rewards_per_token: 100_000_000, // 0% + 100_000 / 1_000_000 = 10%
     },
     100_000;
     "Zero initial rate and rewards, resulting rate 10%"
@@ -277,10 +277,10 @@ struct ExpectedPool {
 #[test_case(
     InitialPool {
         token_supply: 1_000_000,
-        rewards_per_token: 0,
+        accumulated_rewards_per_token: 0,
     },
     ExpectedPool {
-        rewards_per_token: 1_000_000, // 0% + 1_000 / 1_000_000 = 0.1%
+        accumulated_rewards_per_token: 1_000_000, // 0% + 1_000 / 1_000_000 = 0.1%
     },
     1_000;
     "Zero initial rate and rewards, resulting rate 0.1%"
@@ -288,10 +288,10 @@ struct ExpectedPool {
 #[test_case(
     InitialPool {
         token_supply: 1_000_000,
-        rewards_per_token: 0,
+        accumulated_rewards_per_token: 0,
     },
     ExpectedPool {
-        rewards_per_token: 1_000, // 0 + 1 / 1_000_000 = 0.0001%
+        accumulated_rewards_per_token: 1_000, // 0 + 1 / 1_000_000 = 0.0001%
     },
     1;
     "Zero initial rate and rewards, resulting rate 0.0001%"
@@ -299,10 +299,10 @@ struct ExpectedPool {
 #[test_case(
     InitialPool {
         token_supply: 100_000,
-        rewards_per_token: 500_000_000, // 50%
+        accumulated_rewards_per_token: 500_000_000, // 50%
     },
     ExpectedPool {
-        rewards_per_token: 525_000_000, // 50% + 2_500 / 100_000 = 52.5%
+        accumulated_rewards_per_token: 525_000_000, // 50% + 2_500 / 100_000 = 52.5%
     },
     2_500;
     "50% initial rate, rewards increase by 5%, resulting rate 52.5%"
@@ -310,10 +310,10 @@ struct ExpectedPool {
 #[test_case(
     InitialPool {
         token_supply: 100_000,
-        rewards_per_token: 500_000_000, // 50%
+        accumulated_rewards_per_token: 500_000_000, // 50%
     },
     ExpectedPool {
-        rewards_per_token: 1_000_000_000, // 50% + 50_000 / 100_000 = 100%
+        accumulated_rewards_per_token: 1_000_000_000, // 50% + 50_000 / 100_000 = 100%
     },
     50_000;
     "50% initial rate, rewards increase by 100%, resulting rate 100%"
@@ -321,10 +321,10 @@ struct ExpectedPool {
 #[test_case(
     InitialPool {
         token_supply: 100_000,
-        rewards_per_token: 500_000_000, // 50%
+        accumulated_rewards_per_token: 500_000_000, // 50%
     },
     ExpectedPool {
-        rewards_per_token: 1_750_000_000, // 50% + 125_000 / 100_000 = 175%
+        accumulated_rewards_per_token: 1_750_000_000, // 50% + 125_000 / 100_000 = 175%
     },
     125_000;
     "50% initial rate, rewards increase by 250%, resulting rate 175%"
@@ -333,10 +333,10 @@ struct ExpectedPool {
 async fn success(initial: InitialPool, expected: ExpectedPool, reward_amount: u64) {
     let InitialPool {
         token_supply,
-        rewards_per_token,
+        accumulated_rewards_per_token,
     } = initial;
     let ExpectedPool {
-        rewards_per_token: expected_rewards_per_token,
+        accumulated_rewards_per_token: expected_accumulated_rewards_per_token,
     } = expected;
 
     let mint = Pubkey::new_unique();
@@ -350,7 +350,7 @@ async fn success(initial: InitialPool, expected: ExpectedPool, reward_amount: u6
         &mut context,
         &holder_rewards_pool,
         0, // Excess lamports (not used here).
-        rewards_per_token,
+        accumulated_rewards_per_token,
     )
     .await;
     setup_mint(&mut context, &mint, &Pubkey::new_unique(), token_supply).await;
@@ -390,7 +390,7 @@ async fn success(initial: InitialPool, expected: ExpectedPool, reward_amount: u6
     assert_eq!(
         bytemuck::from_bytes::<HolderRewardsPool>(&holder_rewards_pool_account.data),
         &HolderRewardsPool {
-            rewards_per_token: expected_rewards_per_token,
+            accumulated_rewards_per_token: expected_accumulated_rewards_per_token,
         },
     );
 

--- a/program/tests/harvest_rewards.rs
+++ b/program/tests/harvest_rewards.rs
@@ -165,7 +165,7 @@ async fn fail_holder_rewards_pool_incorrect_owner() {
     let holder_rewards_pool = get_holder_rewards_pool_address(&mint);
 
     let mut context = setup().start_with_context().await;
-    setup_holder_rewards_account(&mut context, &holder_rewards, 0, 0).await;
+    setup_holder_rewards_account(&mut context, &holder_rewards, 0, 0, 0).await;
     setup_token_account(&mut context, &token_account, &owner, &mint, 0).await;
     setup_mint(&mut context, &mint, &Pubkey::new_unique(), 0).await;
 
@@ -209,8 +209,8 @@ async fn fail_holder_rewards_pool_incorrect_address() {
     let holder_rewards_pool = Pubkey::new_unique(); // Incorrect holder rewards pool address.
 
     let mut context = setup().start_with_context().await;
-    setup_holder_rewards_pool_account(&mut context, &holder_rewards_pool, 0, 0).await;
-    setup_holder_rewards_account(&mut context, &holder_rewards, 0, 0).await;
+    setup_holder_rewards_pool_account(&mut context, &holder_rewards_pool, 0, 0, 0).await;
+    setup_holder_rewards_account(&mut context, &holder_rewards, 0, 0, 0).await;
     setup_token_account(&mut context, &token_account, &owner, &mint, 0).await;
     setup_mint(&mut context, &mint, &Pubkey::new_unique(), 0).await;
 
@@ -297,7 +297,7 @@ async fn fail_holder_rewards_incorrect_owner() {
     let holder_rewards_pool = get_holder_rewards_pool_address(&mint);
 
     let mut context = setup().start_with_context().await;
-    setup_holder_rewards_pool_account(&mut context, &holder_rewards_pool, 0, 0).await;
+    setup_holder_rewards_pool_account(&mut context, &holder_rewards_pool, 0, 0, 0).await;
     setup_token_account(&mut context, &token_account, &owner, &mint, 0).await;
     setup_mint(&mut context, &mint, &Pubkey::new_unique(), 0).await;
 
@@ -341,8 +341,8 @@ async fn fail_holder_rewards_incorrect_address() {
     let holder_rewards_pool = get_holder_rewards_pool_address(&mint);
 
     let mut context = setup().start_with_context().await;
-    setup_holder_rewards_pool_account(&mut context, &holder_rewards_pool, 0, 0).await;
-    setup_holder_rewards_account(&mut context, &holder_rewards, 0, 0).await;
+    setup_holder_rewards_pool_account(&mut context, &holder_rewards_pool, 0, 0, 0).await;
+    setup_holder_rewards_account(&mut context, &holder_rewards, 0, 0, 0).await;
     setup_token_account(&mut context, &token_account, &owner, &mint, 0).await;
     setup_mint(&mut context, &mint, &Pubkey::new_unique(), 0).await;
 
@@ -381,7 +381,7 @@ async fn fail_holder_rewards_invalid_data() {
     let holder_rewards_pool = get_holder_rewards_pool_address(&mint);
 
     let mut context = setup().start_with_context().await;
-    setup_holder_rewards_pool_account(&mut context, &holder_rewards_pool, 0, 0).await;
+    setup_holder_rewards_pool_account(&mut context, &holder_rewards_pool, 0, 0, 0).await;
     setup_token_account(&mut context, &token_account, &owner, &mint, 0).await;
     setup_mint(&mut context, &mint, &Pubkey::new_unique(), 0).await;
 
@@ -658,6 +658,7 @@ async fn success(
         &mut context,
         &holder_rewards_pool,
         pool_excess_lamports,
+        0, // TODO: Changed in later commit.
         total_rewards,
     )
     .await;
@@ -665,6 +666,7 @@ async fn success(
         &mut context,
         &holder_rewards,
         unharvested_rewards,
+        0, // TODO: Changed in later commit.
         last_seen_total_rewards,
     )
     .await;
@@ -719,6 +721,7 @@ async fn success(
     assert_eq!(
         bytemuck::from_bytes::<HolderRewards>(&holder_rewards_account.data),
         &HolderRewards {
+            last_rewards_per_token: 0,
             last_seen_total_rewards: total_rewards,
             unharvested_rewards: expected_unharvested_rewards,
         }

--- a/program/tests/harvest_rewards.rs
+++ b/program/tests/harvest_rewards.rs
@@ -9,8 +9,7 @@ use {
         state::{get_holder_rewards_address, get_holder_rewards_pool_address, HolderRewards},
     },
     setup::{
-        setup, setup_holder_rewards_account, setup_holder_rewards_pool_account, setup_mint,
-        setup_token_account,
+        setup, setup_holder_rewards_account, setup_holder_rewards_pool_account, setup_token_account,
     },
     solana_program_test::*,
     solana_sdk::{
@@ -26,48 +25,6 @@ use {
 };
 
 #[tokio::test]
-async fn fail_mint_invalid_data() {
-    let owner = Pubkey::new_unique();
-    let mint = Pubkey::new_unique();
-
-    let token_account = get_associated_token_address(&owner, &mint);
-    let holder_rewards = get_holder_rewards_address(&token_account);
-    let holder_rewards_pool = get_holder_rewards_pool_address(&mint);
-
-    let mut context = setup().start_with_context().await;
-
-    // Set up a mint with invalid data.
-    {
-        context.set_account(
-            &mint,
-            &AccountSharedData::new_data(100_000_000, &vec![5; 165], &spl_token_2022::id())
-                .unwrap(),
-        );
-    }
-
-    let instruction = harvest_rewards(&holder_rewards_pool, &holder_rewards, &token_account, &mint);
-
-    let transaction = Transaction::new_signed_with_payer(
-        &[instruction],
-        Some(&context.payer.pubkey()),
-        &[&context.payer],
-        context.last_blockhash,
-    );
-
-    let err = context
-        .banks_client
-        .process_transaction(transaction)
-        .await
-        .unwrap_err()
-        .unwrap();
-
-    assert_eq!(
-        err,
-        TransactionError::InstructionError(0, InstructionError::InvalidAccountData)
-    );
-}
-
-#[tokio::test]
 async fn fail_token_account_invalid_data() {
     let owner = Pubkey::new_unique();
     let mint = Pubkey::new_unique();
@@ -77,7 +34,6 @@ async fn fail_token_account_invalid_data() {
     let holder_rewards_pool = get_holder_rewards_pool_address(&mint);
 
     let mut context = setup().start_with_context().await;
-    setup_mint(&mut context, &mint, &Pubkey::new_unique(), 0).await;
 
     // Setup token account with invalid data.
     {
@@ -128,7 +84,6 @@ async fn fail_token_account_mint_mismatch() {
         0,
     )
     .await;
-    setup_mint(&mut context, &mint, &Pubkey::new_unique(), 0).await;
 
     let instruction = harvest_rewards(&holder_rewards_pool, &holder_rewards, &token_account, &mint);
 
@@ -167,7 +122,6 @@ async fn fail_holder_rewards_pool_incorrect_owner() {
     let mut context = setup().start_with_context().await;
     setup_holder_rewards_account(&mut context, &holder_rewards, 0, 0, 0).await;
     setup_token_account(&mut context, &token_account, &owner, &mint, 0).await;
-    setup_mint(&mut context, &mint, &Pubkey::new_unique(), 0).await;
 
     // Setup holder rewards pool account with incorrect owner.
     {
@@ -212,7 +166,6 @@ async fn fail_holder_rewards_pool_incorrect_address() {
     setup_holder_rewards_pool_account(&mut context, &holder_rewards_pool, 0, 0, 0).await;
     setup_holder_rewards_account(&mut context, &holder_rewards, 0, 0, 0).await;
     setup_token_account(&mut context, &token_account, &owner, &mint, 0).await;
-    setup_mint(&mut context, &mint, &Pubkey::new_unique(), 0).await;
 
     let instruction = harvest_rewards(&holder_rewards_pool, &holder_rewards, &token_account, &mint);
 
@@ -250,7 +203,6 @@ async fn fail_holder_rewards_pool_invalid_data() {
 
     let mut context = setup().start_with_context().await;
     setup_token_account(&mut context, &token_account, &owner, &mint, 0).await;
-    setup_mint(&mut context, &mint, &Pubkey::new_unique(), 0).await;
 
     // Setup holder rewards pool account with invalid data.
     {
@@ -299,7 +251,6 @@ async fn fail_holder_rewards_incorrect_owner() {
     let mut context = setup().start_with_context().await;
     setup_holder_rewards_pool_account(&mut context, &holder_rewards_pool, 0, 0, 0).await;
     setup_token_account(&mut context, &token_account, &owner, &mint, 0).await;
-    setup_mint(&mut context, &mint, &Pubkey::new_unique(), 0).await;
 
     // Setup holder rewards account with incorrect owner.
     {
@@ -344,7 +295,6 @@ async fn fail_holder_rewards_incorrect_address() {
     setup_holder_rewards_pool_account(&mut context, &holder_rewards_pool, 0, 0, 0).await;
     setup_holder_rewards_account(&mut context, &holder_rewards, 0, 0, 0).await;
     setup_token_account(&mut context, &token_account, &owner, &mint, 0).await;
-    setup_mint(&mut context, &mint, &Pubkey::new_unique(), 0).await;
 
     let instruction = harvest_rewards(&holder_rewards_pool, &holder_rewards, &token_account, &mint);
 
@@ -383,7 +333,6 @@ async fn fail_holder_rewards_invalid_data() {
     let mut context = setup().start_with_context().await;
     setup_holder_rewards_pool_account(&mut context, &holder_rewards_pool, 0, 0, 0).await;
     setup_token_account(&mut context, &token_account, &owner, &mint, 0).await;
-    setup_mint(&mut context, &mint, &Pubkey::new_unique(), 0).await;
 
     // Setup holder rewards account with invalid data.
     {
@@ -421,211 +370,129 @@ async fn fail_holder_rewards_invalid_data() {
 }
 
 struct Pool {
-    token_supply: u64,
+    excess_lamports: u64,
+    rewards_per_token: u128,
     total_rewards: u64,
-    pool_excess_lamports: u64,
 }
 
 struct Holder {
     token_account_balance: u64,
+    last_rewards_per_token: u128,
     last_seen_total_rewards: u64,
     unharvested_rewards: u64,
 }
 
 #[test_case(
     Pool {
-        token_supply: 0,
+        excess_lamports: 0,
+        rewards_per_token: 0,
         total_rewards: 0,
-        pool_excess_lamports: 0,
     },
     Holder {
-        token_account_balance: 0,
+        token_account_balance: 100,
+        last_rewards_per_token: 0,
         last_seen_total_rewards: 0,
         unharvested_rewards: 0,
     },
     0,
     0;
-    "all zeroes, no rewards"
+    "All zeroes, no rewards"
 )]
 #[test_case(
     Pool {
-        token_supply: 10_000,
-        total_rewards: 10_000,
-        pool_excess_lamports: 20_000,
+        excess_lamports: 1_000_000,
+        rewards_per_token: 1_000_000_000, // 1 reward per token.
+        total_rewards: 100_000,
     },
     Holder {
-        token_account_balance: 0,
-        last_seen_total_rewards: 0,
+        token_account_balance: 100,
+        last_rewards_per_token: 1_000_000_000, // 1 reward per token.
+        last_seen_total_rewards: 100_000,
         unharvested_rewards: 0,
     },
     0,
     0;
-    "share of token supply is zero, 0 unharvested, 0 last seen, no rewards"
+    "Last harvested 1.0 rate, rate unchanged, no rewards"
 )]
 #[test_case(
     Pool {
-        token_supply: 10_000,
-        total_rewards: 10_000,
-        pool_excess_lamports: 20_000,
+        excess_lamports: 50_000,
+        rewards_per_token: 1_000_000_000, // 1 reward per token.
+        total_rewards: 100_000,
     },
     Holder {
-        token_account_balance: 0,
-        last_seen_total_rewards: 5_000, // Last saw half.
-        unharvested_rewards: 2_500, // Not yet harvested.
-    },
-    2_500, // Fully harvested unharvested rewards.
-    0; // Token account balance is zero, no new rewards.
-    "share of token supply is zero, some unharvested, half last seen, pool has enough, only unharvested"
-)]
-#[test_case(
-    Pool {
-        token_supply: 10_000,
-        total_rewards: 10_000,
-        pool_excess_lamports: 1_000, // Not enough.
-    },
-    Holder {
-        token_account_balance: 0,
-        last_seen_total_rewards: 5_000, // Last saw half.
-        unharvested_rewards: 2_500, // Not yet harvested.
-    },
-    1_000, // Only harvested what was in the pool.
-    2_500 - 1_000; // Token account balance is zero, no new rewards, but some was unharvested since pool was underfunded.
-    "share of token supply is zero, some unharvested, half last seen, pool underfunded, pool excess harvested, rest unharvested"
-)]
-#[test_case(
-    Pool {
-        token_supply: 0,
-        total_rewards: 10_000,
-        pool_excess_lamports: 20_000,
-    },
-    Holder {
-        token_account_balance: 0,
+        token_account_balance: 100_000,
+        last_rewards_per_token: 0,
         last_seen_total_rewards: 0,
         unharvested_rewards: 0,
     },
-    0, // Token supply is zero, no new rewards.
-    0; // No unharvested rewards to harvest.
-    "token supply is zero, 0 unharvested, 0 last seen, no rewards"
+    50_000, // Pool excess.
+    50_000; // Remainder.
+    "No last harvested rate, eligible for 1 rate, pool is underfunded, receive pool excess"
 )]
 #[test_case(
     Pool {
-        token_supply: 0,
-        total_rewards: 10_000,
-        pool_excess_lamports: 20_000,
+        excess_lamports: 1_000_000,
+        rewards_per_token: 1_000_000_000, // 1 reward per token.
+        total_rewards: 100_000,
     },
     Holder {
-        token_account_balance: 0,
-        last_seen_total_rewards: 5_000, // Last saw half.
-        unharvested_rewards: 2_500, // Not yet harvested.
-    },
-    2_500, // Fully harvested unharvested rewards.
-    0; // Token supply is zero, no new rewards.
-    "token supply is zero, some unharvested, half last seen, pool has enough, only unharvested"
-)]
-#[test_case(
-    Pool {
-        token_supply: 0,
-        total_rewards: 10_000,
-        pool_excess_lamports: 1_000, // Not enough.
-    },
-    Holder {
-        token_account_balance: 0,
-        last_seen_total_rewards: 5_000, // Last saw half.
-        unharvested_rewards: 2_500, // Not yet harvested.
-    },
-    1_000, // Only harvested what was in the pool.
-    2_500 - 1_000; // Token supply is zero, no new rewards, but some was unharvested since pool was underfunded.
-    "token supply is zero, some unharvested, half last seen, pool underfunded, pool excess"
-)]
-#[test_case(
-    Pool {
-        token_supply: 10_000,
-        total_rewards: 10_000,
-        pool_excess_lamports: 20_000,
-    },
-    Holder {
-        token_account_balance: 5_000,
+        token_account_balance: 100_000,
+        last_rewards_per_token: 0,
         last_seen_total_rewards: 0,
         unharvested_rewards: 0,
     },
-    5_000, // 50% of total rewards.
-    0; // No unharvested rewards remain, pool had enough.
-    "50% of token supply, 0 unharvested, 0 last seen, pool has enough, 50% of rewards"
+    100_000,
+    0;
+    "No last harvested rate, eligible for 1 rate, pool has enough, receive 100% of rewards"
 )]
 #[test_case(
     Pool {
-        token_supply: 10_000,
-        total_rewards: 10_000,
-        pool_excess_lamports: 2_000, // Not enough.
+        excess_lamports: 1_000_000,
+        rewards_per_token: 1_000_000_000, // 1 reward per token.
+        total_rewards: 100_000,
     },
     Holder {
-        token_account_balance: 5_000,
+        token_account_balance: 10_000,
+        last_rewards_per_token: 0,
         last_seen_total_rewards: 0,
         unharvested_rewards: 0,
     },
-    2_000, // Pool excess.
-    5_000 - 2_000; // 50% of total rewards, but pool was underfunded.
-    "50% of token supply, 0 unharvested, 0 last seen, pool underfunded, pool excess harvested, rest unharvested"
+    10_000,
+    0;
+    "No last harvested rate, eligible for 1 rate, pool has enough, receive share"
 )]
 #[test_case(
     Pool {
-        token_supply: 10_000,
-        total_rewards: 10_000,
-        pool_excess_lamports: 20_000,
+        excess_lamports: 10_000,
+        rewards_per_token: 1_000_000_000, // 1 reward per token.
+        total_rewards: 100_000,
     },
     Holder {
-        token_account_balance: 5_000,
-        last_seen_total_rewards: 5_000, // Last saw half.
-        unharvested_rewards: 0, // Harvested since last seen.
+        token_account_balance: 10_000,
+        last_rewards_per_token: 500_000_000, // 0.5 rewards per token.
+        last_seen_total_rewards: 50_000,
+        unharvested_rewards: 0,
     },
-    2_500, // 50% of unseen rewards.
-    0; // No unharvested rewards remain, pool had enough.
-    "50% of token supply, 0 unharvested, half last seen, pool has enough, half of 50% of rewards"
+    5_000, // (1 - 0.5) * 10_000
+    0;
+    "Last harvested 0.5 rate, eligible for 0.5 rate, pool has enough, receive share"
 )]
 #[test_case(
     Pool {
-        token_supply: 10_000,
-        total_rewards: 10_000,
-        pool_excess_lamports: 1_000, // Not enough.
+        excess_lamports: 10_000,
+        rewards_per_token: 1_000_000_000, // 1 reward per token.
+        total_rewards: 100_000,
     },
     Holder {
-        token_account_balance: 5_000,
-        last_seen_total_rewards: 5_000, // Last saw half.
-        unharvested_rewards: 0, // Harvested since last seen.
+        token_account_balance: 10_000,
+        last_rewards_per_token: 250_000_000, // 0.25 rewards per token.
+        last_seen_total_rewards: 50_000,
+        unharvested_rewards: 0,
     },
-    1_000, // Pool excess.
-    2_500 - 1_000; // 50% of unseen rewards, but pool was underfunded.
-    "50% of token supply, 0 unharvested, half last seen, pool underfunded, pool excess harvested, rest unharvested"
-)]
-#[test_case(
-    Pool {
-        token_supply: 10_000,
-        total_rewards: 10_000,
-        pool_excess_lamports: 20_000,
-    },
-    Holder {
-        token_account_balance: 5_000,
-        last_seen_total_rewards: 5_000, // Last saw half.
-        unharvested_rewards: 2_500, // Not yet harvested.
-    },
-    5_000, // 50% of total rewards.
-    0; // No unharvested rewards remain, pool had enough.
-    "50% of token supply, some unharvested, half last seen, pool has enough, 50% of rewards"
-)]
-#[test_case(
-    Pool {
-        token_supply: 10_000,
-        total_rewards: 10_000,
-        pool_excess_lamports: 1_000, // Not enough.
-    },
-    Holder {
-        token_account_balance: 5_000,
-        last_seen_total_rewards: 5_000, // Last saw half.
-        unharvested_rewards: 2_500, // Not yet harvested.
-    },
-    1_000, // Pool excess.
-    5_000 - 1_000; // 50% of total rewards, but pool was underfunded.
-    "50% of token supply, some unharvested, half last seen, pool underfunded, pool excess harvested, rest unharvested"
+    7_500, // (1 - 0.25) * 10_000
+    0;
+    "Last harvested 0.25 rate, eligible for 0.75 rate, pool has enough, receive share"
 )]
 #[tokio::test]
 async fn success(
@@ -635,13 +502,14 @@ async fn success(
     expected_unharvested_rewards: u64,
 ) {
     let Pool {
-        token_supply,
+        excess_lamports,
+        rewards_per_token,
         total_rewards,
-        pool_excess_lamports,
     } = pool;
 
     let Holder {
         token_account_balance,
+        last_rewards_per_token,
         last_seen_total_rewards,
         unharvested_rewards,
     } = holder;
@@ -657,8 +525,8 @@ async fn success(
     setup_holder_rewards_pool_account(
         &mut context,
         &holder_rewards_pool,
-        pool_excess_lamports,
-        0, // TODO: Changed in later commit.
+        excess_lamports,
+        rewards_per_token,
         total_rewards,
     )
     .await;
@@ -666,7 +534,7 @@ async fn success(
         &mut context,
         &holder_rewards,
         unharvested_rewards,
-        0, // TODO: Changed in later commit.
+        last_rewards_per_token,
         last_seen_total_rewards,
     )
     .await;
@@ -678,7 +546,6 @@ async fn success(
         token_account_balance,
     )
     .await;
-    setup_mint(&mut context, &mint, &Pubkey::new_unique(), token_supply).await;
 
     // For checks later.
     let pool_beginning_lamports = context
@@ -721,7 +588,7 @@ async fn success(
     assert_eq!(
         bytemuck::from_bytes::<HolderRewards>(&holder_rewards_account.data),
         &HolderRewards {
-            last_rewards_per_token: 0,
+            last_rewards_per_token: rewards_per_token,
             last_seen_total_rewards: total_rewards,
             unharvested_rewards: expected_unharvested_rewards,
         }

--- a/program/tests/harvest_rewards.rs
+++ b/program/tests/harvest_rewards.rs
@@ -380,6 +380,14 @@ struct Holder {
     unharvested_rewards: u64,
 }
 
+enum ExpectedResult {
+    Ok {
+        harvested_rewards: u64,
+        unharvested_rewards: u64,
+    },
+    Err,
+}
+
 #[test_case(
     Pool {
         excess_lamports: 0,
@@ -390,8 +398,7 @@ struct Holder {
         last_rewards_per_token: 0,
         unharvested_rewards: 0,
     },
-    0,
-    0;
+    ExpectedResult::Err;
     "All zeroes, no rewards"
 )]
 #[test_case(
@@ -404,8 +411,7 @@ struct Holder {
         last_rewards_per_token: 1_000_000_000, // 1 reward per token.
         unharvested_rewards: 0,
     },
-    0,
-    0;
+    ExpectedResult::Err;
     "Last harvested 1.0 rate, rate unchanged, no rewards"
 )]
 #[test_case(
@@ -418,8 +424,10 @@ struct Holder {
         last_rewards_per_token: 0,
         unharvested_rewards: 0,
     },
-    50_000, // Pool excess.
-    50_000; // Remainder.
+    ExpectedResult::Ok {
+        harvested_rewards: 50_000, // Pool excess.
+        unharvested_rewards: 50_000, // Remainder.
+    };
     "No last harvested rate, eligible for 1 rate, pool is underfunded, receive pool excess"
 )]
 #[test_case(
@@ -432,8 +440,10 @@ struct Holder {
         last_rewards_per_token: 0,
         unharvested_rewards: 0,
     },
-    100_000,
-    0;
+    ExpectedResult::Ok {
+        harvested_rewards: 100_000,
+        unharvested_rewards: 0,
+    };
     "No last harvested rate, eligible for 1 rate, pool has enough, receive 100% of rewards"
 )]
 #[test_case(
@@ -446,8 +456,10 @@ struct Holder {
         last_rewards_per_token: 0,
         unharvested_rewards: 0,
     },
-    10_000,
-    0;
+    ExpectedResult::Ok {
+        harvested_rewards: 10_000,
+        unharvested_rewards: 0,
+    };
     "No last harvested rate, eligible for 1 rate, pool has enough, receive share"
 )]
 #[test_case(
@@ -460,8 +472,10 @@ struct Holder {
         last_rewards_per_token: 500_000_000, // 0.5 rewards per token.
         unharvested_rewards: 0,
     },
-    5_000, // (1 - 0.5) * 10_000
-    0;
+    ExpectedResult::Ok {
+        harvested_rewards: 5_000, // (1 - 0.5) * 10_000
+        unharvested_rewards: 0,
+    };
     "Last harvested 0.5 rate, eligible for 0.5 rate, pool has enough, receive share"
 )]
 #[test_case(
@@ -474,17 +488,14 @@ struct Holder {
         last_rewards_per_token: 250_000_000, // 0.25 rewards per token.
         unharvested_rewards: 0,
     },
-    7_500, // (1 - 0.25) * 10_000
-    0;
+    ExpectedResult::Ok {
+        harvested_rewards: 7_500, // (1 - 0.25) * 10_000
+        unharvested_rewards: 0,
+    };
     "Last harvested 0.25 rate, eligible for 0.75 rate, pool has enough, receive share"
 )]
 #[tokio::test]
-async fn success(
-    pool: Pool,
-    holder: Holder,
-    expected_harvested_rewards: u64,
-    expected_unharvested_rewards: u64,
-) {
+async fn success(pool: Pool, holder: Holder, expected_result: ExpectedResult) {
     let Pool {
         excess_lamports,
         rewards_per_token,
@@ -552,47 +563,70 @@ async fn success(
         context.last_blockhash,
     );
 
-    context
-        .banks_client
-        .process_transaction(transaction)
-        .await
-        .unwrap();
+    let result = context.banks_client.process_transaction(transaction).await;
 
-    // Assert the holder rewards account's unharvested rewards was updated.
     let holder_rewards_account = context
         .banks_client
         .get_account(holder_rewards)
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(
-        bytemuck::from_bytes::<HolderRewards>(&holder_rewards_account.data),
-        &HolderRewards::new(rewards_per_token, expected_unharvested_rewards),
-    );
+    let holder_rewards_state = bytemuck::from_bytes::<HolderRewards>(&holder_rewards_account.data);
 
-    // Assert the holder rewards pool's balance was debited.
-    let pool_resulting_lamports = context
-        .banks_client
-        .get_account(holder_rewards_pool)
-        .await
-        .unwrap()
-        .unwrap()
-        .lamports;
-    assert_eq!(
-        pool_resulting_lamports,
-        pool_beginning_lamports.saturating_sub(expected_harvested_rewards),
-    );
+    match expected_result {
+        ExpectedResult::Ok {
+            harvested_rewards: expected_harvested_rewards,
+            unharvested_rewards: expected_unharvested_rewards,
+        } => {
+            let _result = result.unwrap();
 
-    // Assert the token account's balance was credited.
-    let token_account_resulting_lamports = context
-        .banks_client
-        .get_account(token_account)
-        .await
-        .unwrap()
-        .unwrap()
-        .lamports;
-    assert_eq!(
-        token_account_resulting_lamports,
-        token_account_beginning_lamports.saturating_add(expected_harvested_rewards),
-    );
+            // Assert the holder rewards account state was updated.
+            assert_eq!(
+                holder_rewards_state,
+                &HolderRewards::new(rewards_per_token, expected_unharvested_rewards),
+            );
+
+            // Assert the holder rewards pool's balance was debited.
+            let pool_resulting_lamports = context
+                .banks_client
+                .get_account(holder_rewards_pool)
+                .await
+                .unwrap()
+                .unwrap()
+                .lamports;
+            assert_eq!(
+                pool_resulting_lamports,
+                pool_beginning_lamports.saturating_sub(expected_harvested_rewards),
+            );
+
+            // Assert the token account's balance was credited.
+            let token_account_resulting_lamports = context
+                .banks_client
+                .get_account(token_account)
+                .await
+                .unwrap()
+                .unwrap()
+                .lamports;
+            assert_eq!(
+                token_account_resulting_lamports,
+                token_account_beginning_lamports.saturating_add(expected_harvested_rewards),
+            );
+        }
+        ExpectedResult::Err => {
+            let err = result.unwrap_err().unwrap();
+            assert_eq!(
+                err,
+                TransactionError::InstructionError(
+                    0,
+                    InstructionError::Custom(PaladinRewardsError::NoRewardsToHarvest as u32)
+                )
+            );
+
+            // Assert the holder rewards account account state was _not_ updated.
+            assert_eq!(
+                holder_rewards_state,
+                &HolderRewards::new(last_rewards_per_token, unharvested_rewards),
+            );
+        }
+    }
 }

--- a/program/tests/harvest_rewards.rs
+++ b/program/tests/harvest_rewards.rs
@@ -120,7 +120,7 @@ async fn fail_holder_rewards_pool_incorrect_owner() {
     let holder_rewards_pool = get_holder_rewards_pool_address(&mint);
 
     let mut context = setup().start_with_context().await;
-    setup_holder_rewards_account(&mut context, &holder_rewards, 0, 0, 0).await;
+    setup_holder_rewards_account(&mut context, &holder_rewards, 0, 0).await;
     setup_token_account(&mut context, &token_account, &owner, &mint, 0).await;
 
     // Setup holder rewards pool account with incorrect owner.
@@ -163,8 +163,8 @@ async fn fail_holder_rewards_pool_incorrect_address() {
     let holder_rewards_pool = Pubkey::new_unique(); // Incorrect holder rewards pool address.
 
     let mut context = setup().start_with_context().await;
-    setup_holder_rewards_pool_account(&mut context, &holder_rewards_pool, 0, 0, 0).await;
-    setup_holder_rewards_account(&mut context, &holder_rewards, 0, 0, 0).await;
+    setup_holder_rewards_pool_account(&mut context, &holder_rewards_pool, 0, 0).await;
+    setup_holder_rewards_account(&mut context, &holder_rewards, 0, 0).await;
     setup_token_account(&mut context, &token_account, &owner, &mint, 0).await;
 
     let instruction = harvest_rewards(&holder_rewards_pool, &holder_rewards, &token_account, &mint);
@@ -249,7 +249,7 @@ async fn fail_holder_rewards_incorrect_owner() {
     let holder_rewards_pool = get_holder_rewards_pool_address(&mint);
 
     let mut context = setup().start_with_context().await;
-    setup_holder_rewards_pool_account(&mut context, &holder_rewards_pool, 0, 0, 0).await;
+    setup_holder_rewards_pool_account(&mut context, &holder_rewards_pool, 0, 0).await;
     setup_token_account(&mut context, &token_account, &owner, &mint, 0).await;
 
     // Setup holder rewards account with incorrect owner.
@@ -292,8 +292,8 @@ async fn fail_holder_rewards_incorrect_address() {
     let holder_rewards_pool = get_holder_rewards_pool_address(&mint);
 
     let mut context = setup().start_with_context().await;
-    setup_holder_rewards_pool_account(&mut context, &holder_rewards_pool, 0, 0, 0).await;
-    setup_holder_rewards_account(&mut context, &holder_rewards, 0, 0, 0).await;
+    setup_holder_rewards_pool_account(&mut context, &holder_rewards_pool, 0, 0).await;
+    setup_holder_rewards_account(&mut context, &holder_rewards, 0, 0).await;
     setup_token_account(&mut context, &token_account, &owner, &mint, 0).await;
 
     let instruction = harvest_rewards(&holder_rewards_pool, &holder_rewards, &token_account, &mint);
@@ -331,7 +331,7 @@ async fn fail_holder_rewards_invalid_data() {
     let holder_rewards_pool = get_holder_rewards_pool_address(&mint);
 
     let mut context = setup().start_with_context().await;
-    setup_holder_rewards_pool_account(&mut context, &holder_rewards_pool, 0, 0, 0).await;
+    setup_holder_rewards_pool_account(&mut context, &holder_rewards_pool, 0, 0).await;
     setup_token_account(&mut context, &token_account, &owner, &mint, 0).await;
 
     // Setup holder rewards account with invalid data.
@@ -372,13 +372,11 @@ async fn fail_holder_rewards_invalid_data() {
 struct Pool {
     excess_lamports: u64,
     rewards_per_token: u128,
-    total_rewards: u64,
 }
 
 struct Holder {
     token_account_balance: u64,
     last_rewards_per_token: u128,
-    last_seen_total_rewards: u64,
     unharvested_rewards: u64,
 }
 
@@ -386,12 +384,10 @@ struct Holder {
     Pool {
         excess_lamports: 0,
         rewards_per_token: 0,
-        total_rewards: 0,
     },
     Holder {
         token_account_balance: 100,
         last_rewards_per_token: 0,
-        last_seen_total_rewards: 0,
         unharvested_rewards: 0,
     },
     0,
@@ -402,12 +398,10 @@ struct Holder {
     Pool {
         excess_lamports: 1_000_000,
         rewards_per_token: 1_000_000_000, // 1 reward per token.
-        total_rewards: 100_000,
     },
     Holder {
         token_account_balance: 100,
         last_rewards_per_token: 1_000_000_000, // 1 reward per token.
-        last_seen_total_rewards: 100_000,
         unharvested_rewards: 0,
     },
     0,
@@ -418,12 +412,10 @@ struct Holder {
     Pool {
         excess_lamports: 50_000,
         rewards_per_token: 1_000_000_000, // 1 reward per token.
-        total_rewards: 100_000,
     },
     Holder {
         token_account_balance: 100_000,
         last_rewards_per_token: 0,
-        last_seen_total_rewards: 0,
         unharvested_rewards: 0,
     },
     50_000, // Pool excess.
@@ -434,12 +426,10 @@ struct Holder {
     Pool {
         excess_lamports: 1_000_000,
         rewards_per_token: 1_000_000_000, // 1 reward per token.
-        total_rewards: 100_000,
     },
     Holder {
         token_account_balance: 100_000,
         last_rewards_per_token: 0,
-        last_seen_total_rewards: 0,
         unharvested_rewards: 0,
     },
     100_000,
@@ -450,12 +440,10 @@ struct Holder {
     Pool {
         excess_lamports: 1_000_000,
         rewards_per_token: 1_000_000_000, // 1 reward per token.
-        total_rewards: 100_000,
     },
     Holder {
         token_account_balance: 10_000,
         last_rewards_per_token: 0,
-        last_seen_total_rewards: 0,
         unharvested_rewards: 0,
     },
     10_000,
@@ -466,12 +454,10 @@ struct Holder {
     Pool {
         excess_lamports: 10_000,
         rewards_per_token: 1_000_000_000, // 1 reward per token.
-        total_rewards: 100_000,
     },
     Holder {
         token_account_balance: 10_000,
         last_rewards_per_token: 500_000_000, // 0.5 rewards per token.
-        last_seen_total_rewards: 50_000,
         unharvested_rewards: 0,
     },
     5_000, // (1 - 0.5) * 10_000
@@ -482,12 +468,10 @@ struct Holder {
     Pool {
         excess_lamports: 10_000,
         rewards_per_token: 1_000_000_000, // 1 reward per token.
-        total_rewards: 100_000,
     },
     Holder {
         token_account_balance: 10_000,
         last_rewards_per_token: 250_000_000, // 0.25 rewards per token.
-        last_seen_total_rewards: 50_000,
         unharvested_rewards: 0,
     },
     7_500, // (1 - 0.25) * 10_000
@@ -504,13 +488,11 @@ async fn success(
     let Pool {
         excess_lamports,
         rewards_per_token,
-        total_rewards,
     } = pool;
 
     let Holder {
         token_account_balance,
         last_rewards_per_token,
-        last_seen_total_rewards,
         unharvested_rewards,
     } = holder;
 
@@ -527,7 +509,6 @@ async fn success(
         &holder_rewards_pool,
         excess_lamports,
         rewards_per_token,
-        total_rewards,
     )
     .await;
     setup_holder_rewards_account(
@@ -535,7 +516,6 @@ async fn success(
         &holder_rewards,
         unharvested_rewards,
         last_rewards_per_token,
-        last_seen_total_rewards,
     )
     .await;
     setup_token_account(
@@ -587,11 +567,7 @@ async fn success(
         .unwrap();
     assert_eq!(
         bytemuck::from_bytes::<HolderRewards>(&holder_rewards_account.data),
-        &HolderRewards {
-            last_rewards_per_token: rewards_per_token,
-            last_seen_total_rewards: total_rewards,
-            unharvested_rewards: expected_unharvested_rewards,
-        }
+        &HolderRewards::new(rewards_per_token, expected_unharvested_rewards),
     );
 
     // Assert the holder rewards pool's balance was debited.

--- a/program/tests/initialize_holder_rewards.rs
+++ b/program/tests/initialize_holder_rewards.rs
@@ -165,7 +165,7 @@ async fn fail_holder_rewards_pool_incorrect_address() {
     let holder_rewards_pool = Pubkey::new_unique(); // Incorrect holder rewards pool address.
 
     let mut context = setup().start_with_context().await;
-    setup_holder_rewards_pool_account(&mut context, &holder_rewards_pool, 0, 0, 0).await;
+    setup_holder_rewards_pool_account(&mut context, &holder_rewards_pool, 0, 0).await;
     setup_token_account(&mut context, &token_account, &owner, &mint, 0).await;
     setup_mint(&mut context, &mint, &Pubkey::new_unique(), 0).await;
 
@@ -254,7 +254,7 @@ async fn fail_holder_rewards_incorrect_address() {
     let holder_rewards_pool = get_holder_rewards_pool_address(&mint);
 
     let mut context = setup().start_with_context().await;
-    setup_holder_rewards_pool_account(&mut context, &holder_rewards_pool, 0, 0, 0).await;
+    setup_holder_rewards_pool_account(&mut context, &holder_rewards_pool, 0, 0).await;
     setup_token_account(&mut context, &token_account, &owner, &mint, 0).await;
     setup_mint(&mut context, &mint, &Pubkey::new_unique(), 0).await;
 
@@ -294,7 +294,7 @@ async fn fail_holder_rewards_account_initialized() {
     let holder_rewards_pool = get_holder_rewards_pool_address(&mint);
 
     let mut context = setup().start_with_context().await;
-    setup_holder_rewards_pool_account(&mut context, &holder_rewards_pool, 0, 0, 0).await;
+    setup_holder_rewards_pool_account(&mut context, &holder_rewards_pool, 0, 0).await;
     setup_token_account(&mut context, &token_account, &owner, &mint, 0).await;
     setup_mint(&mut context, &mint, &Pubkey::new_unique(), 0).await;
 
@@ -339,7 +339,6 @@ async fn success() {
     // Since there's no math involved here, we just need to assert that the
     // new holder account records the current pool values.
     let rewards_per_token = 500_000_000;
-    let total_rewards = 100_000;
 
     let owner = Pubkey::new_unique();
     let mint = Pubkey::new_unique();
@@ -354,7 +353,6 @@ async fn success() {
         &holder_rewards_pool,
         0, // Excess lamports (not used here).
         rewards_per_token,
-        total_rewards,
     )
     .await;
     setup_token_account(
@@ -410,10 +408,6 @@ async fn success() {
 
     assert_eq!(
         holder_rewards_state,
-        &HolderRewards {
-            last_rewards_per_token: rewards_per_token,
-            last_seen_total_rewards: total_rewards,
-            unharvested_rewards: 0,
-        },
+        &HolderRewards::new(rewards_per_token, /* unharvested_rewards */ 0),
     );
 }

--- a/program/tests/initialize_holder_rewards.rs
+++ b/program/tests/initialize_holder_rewards.rs
@@ -209,7 +209,7 @@ async fn fail_holder_rewards_pool_incorrect_address() {
     let holder_rewards_pool = Pubkey::new_unique(); // Incorrect holder rewards pool address.
 
     let mut context = setup().start_with_context().await;
-    setup_holder_rewards_pool_account(&mut context, &holder_rewards_pool, 0, 0).await;
+    setup_holder_rewards_pool_account(&mut context, &holder_rewards_pool, 0, 0, 0).await;
     setup_token_account(&mut context, &token_account, &owner, &mint, 0).await;
     setup_mint(&mut context, &mint, &Pubkey::new_unique(), 0).await;
 
@@ -298,7 +298,7 @@ async fn fail_holder_rewards_incorrect_address() {
     let holder_rewards_pool = get_holder_rewards_pool_address(&mint);
 
     let mut context = setup().start_with_context().await;
-    setup_holder_rewards_pool_account(&mut context, &holder_rewards_pool, 0, 0).await;
+    setup_holder_rewards_pool_account(&mut context, &holder_rewards_pool, 0, 0, 0).await;
     setup_token_account(&mut context, &token_account, &owner, &mint, 0).await;
     setup_mint(&mut context, &mint, &Pubkey::new_unique(), 0).await;
 
@@ -338,7 +338,7 @@ async fn fail_holder_rewards_account_initialized() {
     let holder_rewards_pool = get_holder_rewards_pool_address(&mint);
 
     let mut context = setup().start_with_context().await;
-    setup_holder_rewards_pool_account(&mut context, &holder_rewards_pool, 0, 0).await;
+    setup_holder_rewards_pool_account(&mut context, &holder_rewards_pool, 0, 0, 0).await;
     setup_token_account(&mut context, &token_account, &owner, &mint, 0).await;
     setup_mint(&mut context, &mint, &Pubkey::new_unique(), 0).await;
 
@@ -406,6 +406,7 @@ async fn success(token_supply: u64, token_account_balance: u64, available_reward
         &mut context,
         &holder_rewards_pool,
         available_rewards,
+        0, // TODO: Changed in later commit.
         expected_last_seen_total_rewards,
     )
     .await;
@@ -466,6 +467,7 @@ async fn success(token_supply: u64, token_account_balance: u64, available_reward
     assert_eq!(
         holder_rewards_state,
         &HolderRewards {
+            last_rewards_per_token: 0,
             last_seen_total_rewards: expected_last_seen_total_rewards,
             unharvested_rewards: expected_unharvested_rewards,
         },

--- a/program/tests/initialize_holder_rewards.rs
+++ b/program/tests/initialize_holder_rewards.rs
@@ -19,51 +19,7 @@ use {
         transaction::{Transaction, TransactionError},
     },
     spl_associated_token_account::get_associated_token_address,
-    test_case::test_case,
 };
-
-#[tokio::test]
-async fn fail_mint_invalid_data() {
-    let owner = Pubkey::new_unique();
-    let mint = Pubkey::new_unique();
-
-    let token_account = get_associated_token_address(&owner, &mint);
-    let holder_rewards = get_holder_rewards_address(&token_account);
-    let holder_rewards_pool = get_holder_rewards_pool_address(&mint);
-
-    let mut context = setup().start_with_context().await;
-
-    // Set up a mint with invalid data.
-    {
-        context.set_account(
-            &mint,
-            &AccountSharedData::new_data(100_000_000, &vec![5; 165], &spl_token_2022::id())
-                .unwrap(),
-        );
-    }
-
-    let instruction =
-        initialize_holder_rewards(&holder_rewards_pool, &holder_rewards, &token_account, &mint);
-
-    let transaction = Transaction::new_signed_with_payer(
-        &[instruction],
-        Some(&context.payer.pubkey()),
-        &[&context.payer],
-        context.last_blockhash,
-    );
-
-    let err = context
-        .banks_client
-        .process_transaction(transaction)
-        .await
-        .unwrap_err()
-        .unwrap();
-
-    assert_eq!(
-        err,
-        TransactionError::InstructionError(0, InstructionError::InvalidAccountData)
-    );
-}
 
 #[tokio::test]
 async fn fail_token_account_invalid_data() {
@@ -378,20 +334,13 @@ async fn fail_holder_rewards_account_initialized() {
     );
 }
 
-#[allow(clippy::arithmetic_side_effects)]
-#[test_case(0, 0, 0)]
-#[test_case(10, 5, 10)]
-#[test_case(500_000, 1_000, 1_000)]
-#[test_case(500_000, 1_000, 50_000_000)]
-#[test_case(500_000, 1_000, 40_000_000_000)]
-#[test_case(100_000_000, 10_000_000, 1_000)]
-#[test_case(100_000_000, 10_000_000, 50_000_000)]
-#[test_case(100_000_000, 10_000_000, 40_000_000_000)]
-#[test_case(20_000_000_000, 50_000_000, 1_000)]
-#[test_case(20_000_000_000, 50_000_000, 50_000_000)]
-#[test_case(20_000_000_000, 50_000_000, 40_000_000_000)]
 #[tokio::test]
-async fn success(token_supply: u64, token_account_balance: u64, available_rewards: u64) {
+async fn success() {
+    // Since there's no math involved here, we just need to assert that the
+    // new holder account records the current pool values.
+    let rewards_per_token = 500_000_000;
+    let total_rewards = 100_000;
+
     let owner = Pubkey::new_unique();
     let mint = Pubkey::new_unique();
 
@@ -399,15 +348,13 @@ async fn success(token_supply: u64, token_account_balance: u64, available_reward
     let holder_rewards = get_holder_rewards_address(&token_account);
     let holder_rewards_pool = get_holder_rewards_pool_address(&mint);
 
-    let expected_last_seen_total_rewards = available_rewards + 500_000; // Arbitrary.
-
     let mut context = setup().start_with_context().await;
     setup_holder_rewards_pool_account(
         &mut context,
         &holder_rewards_pool,
-        available_rewards,
-        0, // TODO: Changed in later commit.
-        expected_last_seen_total_rewards,
+        0, // Excess lamports (not used here).
+        rewards_per_token,
+        total_rewards,
     )
     .await;
     setup_token_account(
@@ -415,10 +362,16 @@ async fn success(token_supply: u64, token_account_balance: u64, available_reward
         &token_account,
         &owner,
         &mint,
-        token_account_balance,
+        100, // Token account balance (not used here).
     )
     .await;
-    setup_mint(&mut context, &mint, &Pubkey::new_unique(), token_supply).await;
+    setup_mint(
+        &mut context,
+        &mint,
+        &Pubkey::new_unique(),
+        100_000, // Token supply (not used here).
+    )
+    .await;
 
     // Fund the holder rewards account.
     {
@@ -446,15 +399,6 @@ async fn success(token_supply: u64, token_account_balance: u64, available_reward
         .await
         .unwrap();
 
-    let expected_unharvested_rewards = {
-        if token_supply == 0 {
-            0
-        } else {
-            ((token_account_balance as u128) * (available_rewards as u128) / (token_supply as u128))
-                as u64
-        }
-    };
-
     // Check the holder rewards account.
     let holder_rewards_account = context
         .banks_client
@@ -467,15 +411,9 @@ async fn success(token_supply: u64, token_account_balance: u64, available_reward
     assert_eq!(
         holder_rewards_state,
         &HolderRewards {
-            last_rewards_per_token: 0,
-            last_seen_total_rewards: expected_last_seen_total_rewards,
-            unharvested_rewards: expected_unharvested_rewards,
+            last_rewards_per_token: rewards_per_token,
+            last_seen_total_rewards: total_rewards,
+            unharvested_rewards: 0,
         },
     );
-
-    // If token supply was not zero, ensure the calculated unharvested rewards is
-    // non-zero.
-    if token_supply != 0 {
-        assert_ne!(holder_rewards_state.unharvested_rewards, 0);
-    }
 }

--- a/program/tests/initialize_holder_rewards.rs
+++ b/program/tests/initialize_holder_rewards.rs
@@ -338,7 +338,7 @@ async fn fail_holder_rewards_account_initialized() {
 async fn success() {
     // Since there's no math involved here, we just need to assert that the
     // new holder account records the current pool values.
-    let rewards_per_token = 500_000_000;
+    let accumulated_rewards_per_token = 500_000_000;
 
     let owner = Pubkey::new_unique();
     let mint = Pubkey::new_unique();
@@ -352,7 +352,7 @@ async fn success() {
         &mut context,
         &holder_rewards_pool,
         0, // Excess lamports (not used here).
-        rewards_per_token,
+        accumulated_rewards_per_token,
     )
     .await;
     setup_token_account(
@@ -408,6 +408,9 @@ async fn success() {
 
     assert_eq!(
         holder_rewards_state,
-        &HolderRewards::new(rewards_per_token, /* unharvested_rewards */ 0),
+        &HolderRewards::new(
+            accumulated_rewards_per_token,
+            /* unharvested_rewards */ 0
+        ),
     );
 }

--- a/program/tests/initialize_holder_rewards_pool.rs
+++ b/program/tests/initialize_holder_rewards_pool.rs
@@ -550,7 +550,7 @@ async fn success() {
         .unwrap();
     assert_eq!(
         bytemuck::from_bytes::<HolderRewardsPool>(&holder_rewards_pool_account.data),
-        &HolderRewardsPool { total_rewards: 0 }
+        &HolderRewardsPool::default(),
     );
 
     // Check the extra metas account.

--- a/program/tests/setup.rs
+++ b/program/tests/setup.rs
@@ -129,9 +129,11 @@ pub async fn setup_holder_rewards_pool_account(
     context: &mut ProgramTestContext,
     holder_rewards_pool_address: &Pubkey,
     excess_lamports: u64,
-    rewards_per_token: u128,
+    accumulated_rewards_per_token: u128,
 ) {
-    let state = HolderRewardsPool { rewards_per_token };
+    let state = HolderRewardsPool {
+        accumulated_rewards_per_token,
+    };
     let data = bytemuck::bytes_of(&state).to_vec();
 
     let rent = context.banks_client.get_rent().await.unwrap();
@@ -153,9 +155,9 @@ pub async fn setup_holder_rewards_account(
     context: &mut ProgramTestContext,
     holder_rewards: &Pubkey,
     unharvested_rewards: u64,
-    last_rewards_per_token: u128,
+    last_accumulated_rewards_per_token: u128,
 ) {
-    let state = HolderRewards::new(last_rewards_per_token, unharvested_rewards);
+    let state = HolderRewards::new(last_accumulated_rewards_per_token, unharvested_rewards);
     let data = bytemuck::bytes_of(&state).to_vec();
 
     let rent = context.banks_client.get_rent().await.unwrap();

--- a/program/tests/setup.rs
+++ b/program/tests/setup.rs
@@ -130,9 +130,8 @@ pub async fn setup_holder_rewards_pool_account(
     holder_rewards_pool_address: &Pubkey,
     excess_lamports: u64,
     rewards_per_token: u128,
-    total_rewards: u64,
 ) {
-    let state = HolderRewardsPool::new(rewards_per_token, total_rewards);
+    let state = HolderRewardsPool { rewards_per_token };
     let data = bytemuck::bytes_of(&state).to_vec();
 
     let rent = context.banks_client.get_rent().await.unwrap();
@@ -155,13 +154,8 @@ pub async fn setup_holder_rewards_account(
     holder_rewards: &Pubkey,
     unharvested_rewards: u64,
     last_rewards_per_token: u128,
-    last_seen_total_rewards: u64,
 ) {
-    let state = HolderRewards {
-        last_rewards_per_token,
-        last_seen_total_rewards,
-        unharvested_rewards,
-    };
+    let state = HolderRewards::new(last_rewards_per_token, unharvested_rewards);
     let data = bytemuck::bytes_of(&state).to_vec();
 
     let rent = context.banks_client.get_rent().await.unwrap();

--- a/program/tests/setup.rs
+++ b/program/tests/setup.rs
@@ -129,9 +129,10 @@ pub async fn setup_holder_rewards_pool_account(
     context: &mut ProgramTestContext,
     holder_rewards_pool_address: &Pubkey,
     excess_lamports: u64,
+    rewards_per_token: u128,
     total_rewards: u64,
 ) {
-    let state = HolderRewardsPool { total_rewards };
+    let state = HolderRewardsPool::new(rewards_per_token, total_rewards);
     let data = bytemuck::bytes_of(&state).to_vec();
 
     let rent = context.banks_client.get_rent().await.unwrap();
@@ -153,11 +154,13 @@ pub async fn setup_holder_rewards_account(
     context: &mut ProgramTestContext,
     holder_rewards: &Pubkey,
     unharvested_rewards: u64,
+    last_rewards_per_token: u128,
     last_seen_total_rewards: u64,
 ) {
     let state = HolderRewards {
-        unharvested_rewards,
+        last_rewards_per_token,
         last_seen_total_rewards,
+        unharvested_rewards,
     };
     let data = bytemuck::bytes_of(&state).to_vec();
 


### PR DESCRIPTION
#### Problem
The program's design currently allows for some reward slippage when the token
supply changes - either from minting or burning tokens.

With an implementation that revolves around the concept of "rewards per token"
as a stored exchange rate in the pool, a changing token supply can be handled
more deterministically.

#### Summary of Changes
This PR is a little bit on the larger side, so I'm happy to break things up if we want
to do so.

- First refactor some helpers to prepare for the changes.
- Then add the mint to the list of accounts for `DistributeRewards`.
- Next update the two state types to include `rewards_per_token` and
  `last_rewards_per_token`.
- Generate the IDL and clients with the new changes.
- Implement the new calculation for working with "rewards per token" in the
  processor for `DistributeRewards`.
- Implement the new calculations in the processor for `InitializeHolderRewards`.
- Implement the new calculations in the processor for `HarvestRewards`.

I've included an overview of the new mechanism in the documentation on the
`state` module, should we decide to keep it in the source.