### PR TITLE
Add prop tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -435,6 +435,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1921,6 +1936,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
+name = "libm"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+
+[[package]]
 name = "libsecp256k1"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2296,6 +2317,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -2403,6 +2425,7 @@ dependencies = [
  "bytemuck",
  "num-derive 0.3.3",
  "num-traits",
+ "proptest",
  "shank",
  "solana-program",
  "solana-program-test",
@@ -2680,6 +2703,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c2511913b88df1637da85cc8d96ec8e43a3f8bb8ccb71ee1ac240d6f3df58d"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags 2.6.0",
+ "lazy_static",
+ "num-traits",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "prost"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2752,6 +2795,12 @@ dependencies = [
  "quote",
  "syn 2.0.72",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quinn"
@@ -2879,6 +2928,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+dependencies = [
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3158,6 +3216,18 @@ name = "rustversion"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -5562,6 +5632,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicase"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5684,6 +5760,15 @@ name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -21,6 +21,7 @@ spl-transfer-hook-interface = "0.7.0"
 thiserror = "1.0"
 
 [dev-dependencies]
+proptest = "1.5.0"
 solana-program-test = "2.0.2"
 solana-sdk = "2.0.2"
 spl-pod = "0.3.0"

--- a/program/proptest-regressions/processor.txt
+++ b/program/proptest-regressions/processor.txt
@@ -1,8 +1,0 @@
-# Seeds for failure cases proptest has generated in the past. It is
-# automatically read and these particular cases re-run before any
-# novel cases are generated.
-#
-# It is recommended to check this file in to source control so that
-# everyone who runs the test benefits from these saved cases.
-cc dbe8aa527a2c47a03052931394e13ab4471049b28c043522f1ce2ff7a1a5337d # shrinks to current_accumulated_rewards_per_token = 0, last_accumulated_rewards_per_token = 1, token_account_balance = 0
-cc 05aa29e9ea9b6770294bd3bbb3b83df99fca59e49bea311c8da2a34c35ac1632 # shrinks to current_accumulated_rewards_per_token = 0, last_accumulated_rewards_per_token = 1, token_account_balance = 0

--- a/program/proptest-regressions/processor.txt
+++ b/program/proptest-regressions/processor.txt
@@ -1,0 +1,8 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc dbe8aa527a2c47a03052931394e13ab4471049b28c043522f1ce2ff7a1a5337d # shrinks to current_accumulated_rewards_per_token = 0, last_accumulated_rewards_per_token = 1, token_account_balance = 0
+cc 05aa29e9ea9b6770294bd3bbb3b83df99fca59e49bea311c8da2a34c35ac1632 # shrinks to current_accumulated_rewards_per_token = 0, last_accumulated_rewards_per_token = 1, token_account_balance = 0

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -671,6 +671,19 @@ pub fn process(program_id: &Pubkey, accounts: &[AccountInfo], input: &[u8]) -> P
 mod tests {
     use {super::*, proptest::prelude::*};
 
+    #[test]
+    fn maximum_eligible_rewards() {
+        // 1 lamport per token (not actually possible, but shows that we're ok)
+        let maximum_marginal_rewards_per_token = REWARDS_PER_TOKEN_SCALING_FACTOR;
+        let maximum_token_balance = 1_000_000_000 * 1_000_000_000; // 1 billion with 9 decimals
+        let _ = calculate_eligible_rewards(
+            maximum_marginal_rewards_per_token,
+            0,
+            maximum_token_balance,
+        )
+        .unwrap();
+    }
+
     proptest! {
         #[test]
         fn test_calculate_rewards_per_token(


### PR DESCRIPTION
#### Problem
The rewards program has some extensive test coverage, but it's missing
regression testing to ensure the arithmetic in reward and "last seen rate"
calculation is tight.

#### Summary of Changes
Add prop tests to test the rewards and rate arithmetic.