### PR TITLE
Processor: Increase rewards per token precision

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ instruction and can be claimed by holders.
 struct HolderRewardsPool {
     /// The current rewards per token exchange rate.
     ///
-    /// Stored as a `u128`, which includes a scaling factor of `1e9` to
-    /// represent the exchange rate with 9 decimal places of precision.
+    /// Stored as a `u128`, which includes a scaling factor of `1e18` to
+    /// represent the exchange rate with 18 decimal places of precision.
     pub accumulated_rewards_per_token: u128,
 }
 ```
@@ -38,8 +38,8 @@ the Holder Rewards Pool, tracks the rewards a particular holder can claim.
 struct HolderRewards {
     /// The rewards per token exchange rate when this holder last harvested.
     ///
-    /// Stored as a `u128`, which includes a scaling factor of `1e9` to
-    /// represent the exchange rate with 9 decimal places of precision.
+    /// Stored as a `u128`, which includes a scaling factor of `1e18` to
+    /// represent the exchange rate with 18 decimal places of precision.
     pub last_accumulated_rewards_per_token: u128,
     /// The amount of unharvested rewards currently stored in the holder
     /// rewards account that can be harvested by the holder.

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -713,6 +713,50 @@ mod tests {
     }
 
     #[test]
+    fn minimum_eligible_rewards_with_one_token() {
+        // 1 / 1e9 lamports per token
+        let minimum_marginal_rewards_per_token = 1_000_000_000;
+        let result = calculate_eligible_rewards(
+            minimum_marginal_rewards_per_token,
+            0,
+            BENCH_TOKEN_SUPPLY / 1_000_000_000, // 1 with 9 decimals.
+        )
+        .unwrap();
+        assert_ne!(result, 0);
+
+        // Anything below the minimum should return zero.
+        let result = calculate_eligible_rewards(
+            minimum_marginal_rewards_per_token - 1,
+            0,
+            BENCH_TOKEN_SUPPLY / 1_000_000_000, // 1 with 9 decimals.
+        )
+        .unwrap();
+        assert_eq!(result, 0);
+    }
+
+    #[test]
+    fn minimum_eligible_rewards_with_smallest_fractional_token() {
+        // 1 lamport per token
+        let minimum_marginal_rewards_per_token = 1_000_000_000_000_000_000;
+        let result = calculate_eligible_rewards(
+            minimum_marginal_rewards_per_token,
+            0,
+            BENCH_TOKEN_SUPPLY / 1_000_000_000_000_000_000, // .000_000_001 with 9 decimals.
+        )
+        .unwrap();
+        assert_ne!(result, 0);
+
+        // Anything below the minimum should return zero.
+        let result = calculate_eligible_rewards(
+            minimum_marginal_rewards_per_token - 1,
+            0,
+            BENCH_TOKEN_SUPPLY / 1_000_000_000_000_000_000, // .000_000_001 with 9 decimals.
+        )
+        .unwrap();
+        assert_eq!(result, 0);
+    }
+
+    #[test]
     fn maximum_eligible_rewards() {
         // 1 lamport per token (not really practical, but shows that we're ok)
         let maximum_marginal_rewards_per_token = REWARDS_PER_TOKEN_SCALING_FACTOR;

--- a/program/src/state.rs
+++ b/program/src/state.rs
@@ -223,8 +223,8 @@ pub(crate) fn collect_holder_rewards_pool_signer_seeds<'a>(
 pub struct HolderRewards {
     /// The rewards per token exchange rate when this holder last harvested.
     ///
-    /// Stored as a `u128`, which includes a scaling factor of `1e9` to
-    /// represent the exchange rate with 9 decimal places of precision.
+    /// Stored as a `u128`, which includes a scaling factor of `1e18` to
+    /// represent the exchange rate with 18 decimal places of precision.
     pub last_accumulated_rewards_per_token: u128,
     /// The amount of unharvested rewards currently stored in the holder
     /// rewards account that can be harvested by the holder.
@@ -250,7 +250,7 @@ impl HolderRewards {
 pub struct HolderRewardsPool {
     /// The current rewards per token exchange rate.
     ///
-    /// Stored as a `u128`, which includes a scaling factor of `1e9` to
-    /// represent the exchange rate with 9 decimal places of precision.
+    /// Stored as a `u128`, which includes a scaling factor of `1e18` to
+    /// represent the exchange rate with 18 decimal places of precision.
     pub accumulated_rewards_per_token: u128,
 }

--- a/program/tests/distribute_rewards.rs
+++ b/program/tests/distribute_rewards.rs
@@ -262,7 +262,7 @@ struct ExpectedPool {
         accumulated_rewards_per_token: 0,
     },
     ExpectedPool {
-        accumulated_rewards_per_token: 2_500_000_000, // 0% + 250_000 / 100_000 = 250%
+        accumulated_rewards_per_token: 2_500_000_000_000_000_000, // 0% + 250_000 / 100_000 = 250%
     },
     250_000;
     "Zero initial rate and rewards, resulting rate 250%"
@@ -273,7 +273,7 @@ struct ExpectedPool {
         accumulated_rewards_per_token: 0,
     },
     ExpectedPool {
-        accumulated_rewards_per_token: 100_000_000, // 0% + 100_000 / 1_000_000 = 10%
+        accumulated_rewards_per_token: 100_000_000_000_000_000, // 0% + 100_000 / 1_000_000 = 10%
     },
     100_000;
     "Zero initial rate and rewards, resulting rate 10%"
@@ -284,7 +284,7 @@ struct ExpectedPool {
         accumulated_rewards_per_token: 0,
     },
     ExpectedPool {
-        accumulated_rewards_per_token: 1_000_000, // 0% + 1_000 / 1_000_000 = 0.1%
+        accumulated_rewards_per_token: 1_000_000_000_000_000, // 0% + 1_000 / 1_000_000 = 0.1%
     },
     1_000;
     "Zero initial rate and rewards, resulting rate 0.1%"
@@ -295,7 +295,7 @@ struct ExpectedPool {
         accumulated_rewards_per_token: 0,
     },
     ExpectedPool {
-        accumulated_rewards_per_token: 1_000, // 0 + 1 / 1_000_000 = 0.0001%
+        accumulated_rewards_per_token: 1_000_000_000_000, // 0 + 1 / 1_000_000 = 0.0001%
     },
     1;
     "Zero initial rate and rewards, resulting rate 0.0001%"
@@ -303,10 +303,10 @@ struct ExpectedPool {
 #[test_case(
     InitialPool {
         token_supply: 100_000,
-        accumulated_rewards_per_token: 500_000_000, // 50%
+        accumulated_rewards_per_token: 500_000_000_000_000_000, // 50%
     },
     ExpectedPool {
-        accumulated_rewards_per_token: 525_000_000, // 50% + 2_500 / 100_000 = 52.5%
+        accumulated_rewards_per_token: 525_000_000_000_000_000, // 50% + 2_500 / 100_000 = 52.5%
     },
     2_500;
     "50% initial rate, rewards increase by 5%, resulting rate 52.5%"
@@ -314,10 +314,10 @@ struct ExpectedPool {
 #[test_case(
     InitialPool {
         token_supply: 100_000,
-        accumulated_rewards_per_token: 500_000_000, // 50%
+        accumulated_rewards_per_token: 500_000_000_000_000_000, // 50%
     },
     ExpectedPool {
-        accumulated_rewards_per_token: 1_000_000_000, // 50% + 50_000 / 100_000 = 100%
+        accumulated_rewards_per_token: 1_000_000_000_000_000_000, // 50% + 50_000 / 100_000 = 100%
     },
     50_000;
     "50% initial rate, rewards increase by 100%, resulting rate 100%"
@@ -325,10 +325,10 @@ struct ExpectedPool {
 #[test_case(
     InitialPool {
         token_supply: 100_000,
-        accumulated_rewards_per_token: 500_000_000, // 50%
+        accumulated_rewards_per_token: 500_000_000_000_000_000, // 50%
     },
     ExpectedPool {
-        accumulated_rewards_per_token: 1_750_000_000, // 50% + 125_000 / 100_000 = 175%
+        accumulated_rewards_per_token: 1_750_000_000_000_000_000, // 50% + 125_000 / 100_000 = 175%
     },
     125_000;
     "50% initial rate, rewards increase by 250%, resulting rate 175%"

--- a/program/tests/e2e.rs
+++ b/program/tests/e2e.rs
@@ -424,7 +424,7 @@ async fn test_e2e() {
                 &mint,
                 Pool {
                     token_supply: 100,
-                    accumulated_rewards_per_token: 1_000_000_000,
+                    accumulated_rewards_per_token: 1_000_000_000_000_000_000,
                     pool_excess_lamports: 100,
                 },
                 &[],
@@ -495,7 +495,7 @@ async fn test_e2e() {
             &mint,
             Pool {
                 token_supply: 125,
-                accumulated_rewards_per_token: 1_000_000_000,
+                accumulated_rewards_per_token: 1_000_000_000_000_000_000,
                 pool_excess_lamports: 100,
             },
             &[
@@ -527,7 +527,7 @@ async fn test_e2e() {
                     &dave_token_account,
                     Holder {
                         token_account_balance: 25,
-                        last_accumulated_rewards_per_token: 1_000_000_000,
+                        last_accumulated_rewards_per_token: 1_000_000_000_000_000_000,
                         unharvested_rewards: 0,
                     },
                 ),
@@ -576,7 +576,7 @@ async fn test_e2e() {
             &mint,
             Pool {
                 token_supply: 125,
-                accumulated_rewards_per_token: 1_000_000_000,
+                accumulated_rewards_per_token: 1_000_000_000_000_000_000,
                 pool_excess_lamports: 60,
             },
             &[
@@ -592,7 +592,7 @@ async fn test_e2e() {
                     &bob_token_account,
                     Holder {
                         token_account_balance: 40,
-                        last_accumulated_rewards_per_token: 1_000_000_000,
+                        last_accumulated_rewards_per_token: 1_000_000_000_000_000_000,
                         unharvested_rewards: 0,
                     },
                 ),
@@ -608,7 +608,7 @@ async fn test_e2e() {
                     &dave_token_account,
                     Holder {
                         token_account_balance: 25,
-                        last_accumulated_rewards_per_token: 1_000_000_000,
+                        last_accumulated_rewards_per_token: 1_000_000_000_000_000_000,
                         unharvested_rewards: 0,
                     },
                 ),
@@ -674,7 +674,7 @@ async fn test_e2e() {
             &mint,
             Pool {
                 token_supply: 100,
-                accumulated_rewards_per_token: 1_000_000_000,
+                accumulated_rewards_per_token: 1_000_000_000_000_000_000,
                 pool_excess_lamports: 35,
             },
             &[
@@ -682,7 +682,7 @@ async fn test_e2e() {
                     &alice_token_account,
                     Holder {
                         token_account_balance: 0,
-                        last_accumulated_rewards_per_token: 1_000_000_000,
+                        last_accumulated_rewards_per_token: 1_000_000_000_000_000_000,
                         unharvested_rewards: 0,
                     },
                 ),
@@ -690,7 +690,7 @@ async fn test_e2e() {
                     &bob_token_account,
                     Holder {
                         token_account_balance: 40,
-                        last_accumulated_rewards_per_token: 1_000_000_000,
+                        last_accumulated_rewards_per_token: 1_000_000_000_000_000_000,
                         unharvested_rewards: 0,
                     },
                 ),
@@ -706,7 +706,7 @@ async fn test_e2e() {
                     &dave_token_account,
                     Holder {
                         token_account_balance: 25,
-                        last_accumulated_rewards_per_token: 1_000_000_000,
+                        last_accumulated_rewards_per_token: 1_000_000_000_000_000_000,
                         unharvested_rewards: 0,
                     },
                 ),
@@ -771,7 +771,7 @@ async fn test_e2e() {
             &mint,
             Pool {
                 token_supply: 100,
-                accumulated_rewards_per_token: 3_000_000_000,
+                accumulated_rewards_per_token: 3_000_000_000_000_000_000,
                 pool_excess_lamports: 235,
             },
             &[
@@ -779,7 +779,7 @@ async fn test_e2e() {
                     &alice_token_account,
                     Holder {
                         token_account_balance: 0,
-                        last_accumulated_rewards_per_token: 1_000_000_000,
+                        last_accumulated_rewards_per_token: 1_000_000_000_000_000_000,
                         unharvested_rewards: 0,
                     },
                 ),
@@ -787,7 +787,7 @@ async fn test_e2e() {
                     &bob_token_account,
                     Holder {
                         token_account_balance: 40,
-                        last_accumulated_rewards_per_token: 1_000_000_000,
+                        last_accumulated_rewards_per_token: 1_000_000_000_000_000_000,
                         unharvested_rewards: 0,
                     },
                 ),
@@ -803,7 +803,7 @@ async fn test_e2e() {
                     &dave_token_account,
                     Holder {
                         token_account_balance: 25,
-                        last_accumulated_rewards_per_token: 1_000_000_000,
+                        last_accumulated_rewards_per_token: 1_000_000_000_000_000_000,
                         unharvested_rewards: 0,
                     },
                 ),
@@ -863,7 +863,7 @@ async fn test_e2e() {
             &mint,
             Pool {
                 token_supply: 100,
-                accumulated_rewards_per_token: 3_000_000_000,
+                accumulated_rewards_per_token: 3_000_000_000_000_000_000,
                 pool_excess_lamports: 235,
             },
             &[
@@ -871,7 +871,7 @@ async fn test_e2e() {
                     &alice_token_account,
                     Holder {
                         token_account_balance: 0,
-                        last_accumulated_rewards_per_token: 1_000_000_000,
+                        last_accumulated_rewards_per_token: 1_000_000_000_000_000_000,
                         unharvested_rewards: 0,
                     },
                 ),
@@ -879,7 +879,7 @@ async fn test_e2e() {
                     &bob_token_account,
                     Holder {
                         token_account_balance: 40,
-                        last_accumulated_rewards_per_token: 1_000_000_000,
+                        last_accumulated_rewards_per_token: 1_000_000_000_000_000_000,
                         unharvested_rewards: 0,
                     },
                 ),
@@ -887,7 +887,7 @@ async fn test_e2e() {
                     &carol_token_account,
                     Holder {
                         token_account_balance: 0,
-                        last_accumulated_rewards_per_token: 3_000_000_000,
+                        last_accumulated_rewards_per_token: 3_000_000_000_000_000_000,
                         unharvested_rewards: 105,
                     },
                 ),
@@ -895,7 +895,7 @@ async fn test_e2e() {
                     &dave_token_account,
                     Holder {
                         token_account_balance: 60,
-                        last_accumulated_rewards_per_token: 3_000_000_000,
+                        last_accumulated_rewards_per_token: 3_000_000_000_000_000_000,
                         unharvested_rewards: 50,
                     },
                 ),
@@ -953,7 +953,7 @@ async fn test_e2e() {
             &mint,
             Pool {
                 token_supply: 100,
-                accumulated_rewards_per_token: 6_000_000_000,
+                accumulated_rewards_per_token: 6_000_000_000_000_000_000,
                 pool_excess_lamports: 535,
             },
             &[
@@ -961,7 +961,7 @@ async fn test_e2e() {
                     &alice_token_account,
                     Holder {
                         token_account_balance: 0,
-                        last_accumulated_rewards_per_token: 1_000_000_000,
+                        last_accumulated_rewards_per_token: 1_000_000_000_000_000_000,
                         unharvested_rewards: 0,
                     },
                 ),
@@ -969,7 +969,7 @@ async fn test_e2e() {
                     &bob_token_account,
                     Holder {
                         token_account_balance: 40,
-                        last_accumulated_rewards_per_token: 1_000_000_000,
+                        last_accumulated_rewards_per_token: 1_000_000_000_000_000_000,
                         unharvested_rewards: 0,
                     },
                 ),
@@ -977,7 +977,7 @@ async fn test_e2e() {
                     &carol_token_account,
                     Holder {
                         token_account_balance: 0,
-                        last_accumulated_rewards_per_token: 3_000_000_000,
+                        last_accumulated_rewards_per_token: 3_000_000_000_000_000_000,
                         unharvested_rewards: 105,
                     },
                 ),
@@ -985,7 +985,7 @@ async fn test_e2e() {
                     &dave_token_account,
                     Holder {
                         token_account_balance: 60,
-                        last_accumulated_rewards_per_token: 3_000_000_000,
+                        last_accumulated_rewards_per_token: 3_000_000_000_000_000_000,
                         unharvested_rewards: 50,
                     },
                 ),
@@ -1062,7 +1062,7 @@ async fn test_e2e() {
             &mint,
             Pool {
                 token_supply: 100,
-                accumulated_rewards_per_token: 6_000_000_000,
+                accumulated_rewards_per_token: 6_000_000_000_000_000_000,
                 pool_excess_lamports: 0,
             },
             &[
@@ -1070,7 +1070,7 @@ async fn test_e2e() {
                     &alice_token_account,
                     Holder {
                         token_account_balance: 0,
-                        last_accumulated_rewards_per_token: 1_000_000_000,
+                        last_accumulated_rewards_per_token: 1_000_000_000_000_000_000,
                         unharvested_rewards: 0,
                     },
                 ),
@@ -1078,7 +1078,7 @@ async fn test_e2e() {
                     &bob_token_account,
                     Holder {
                         token_account_balance: 40,
-                        last_accumulated_rewards_per_token: 6_000_000_000,
+                        last_accumulated_rewards_per_token: 6_000_000_000_000_000_000,
                         unharvested_rewards: 0,
                     },
                 ),
@@ -1086,7 +1086,7 @@ async fn test_e2e() {
                     &carol_token_account,
                     Holder {
                         token_account_balance: 0,
-                        last_accumulated_rewards_per_token: 6_000_000_000,
+                        last_accumulated_rewards_per_token: 6_000_000_000_000_000_000,
                         unharvested_rewards: 0,
                     },
                 ),
@@ -1094,7 +1094,7 @@ async fn test_e2e() {
                     &dave_token_account,
                     Holder {
                         token_account_balance: 60,
-                        last_accumulated_rewards_per_token: 6_000_000_000,
+                        last_accumulated_rewards_per_token: 6_000_000_000_000_000_000,
                         unharvested_rewards: 0,
                     },
                 ),

--- a/program/tests/harvest_rewards.rs
+++ b/program/tests/harvest_rewards.rs
@@ -404,11 +404,11 @@ struct Holder {
 #[test_case(
     Pool {
         excess_lamports: 1_000_000,
-        accumulated_rewards_per_token: 1_000_000_000, // 1 reward per token.
+        accumulated_rewards_per_token: 1_000_000_000_000_000_000, // 1 reward per token.
     },
     Holder {
         token_account_balance: 100,
-        last_accumulated_rewards_per_token: 1_000_000_000, // 1 reward per token.
+        last_accumulated_rewards_per_token: 1_000_000_000_000_000_000, // 1 reward per token.
         unharvested_rewards: 0,
     },
     0,
@@ -418,11 +418,11 @@ struct Holder {
 #[test_case(
     Pool {
         excess_lamports: 1_000_000,
-        accumulated_rewards_per_token: 1_000_000_000, // 1 reward per token.
+        accumulated_rewards_per_token: 1_000_000_000_000_000_000, // 1 reward per token.
     },
     Holder {
         token_account_balance: 100,
-        last_accumulated_rewards_per_token: 1_000_000_000, // 1 reward per token.
+        last_accumulated_rewards_per_token: 1_000_000_000_000_000_000, // 1 reward per token.
         unharvested_rewards: 500_000,
     },
     500_000, // Unharvested.
@@ -432,7 +432,7 @@ struct Holder {
 #[test_case(
     Pool {
         excess_lamports: 50_000,
-        accumulated_rewards_per_token: 1_000_000_000, // 1 reward per token.
+        accumulated_rewards_per_token: 1_000_000_000_000_000_000, // 1 reward per token.
     },
     Holder {
         token_account_balance: 100_000,
@@ -446,7 +446,7 @@ struct Holder {
 #[test_case(
     Pool {
         excess_lamports: 1_000_000,
-        accumulated_rewards_per_token: 1_000_000_000, // 1 reward per token.
+        accumulated_rewards_per_token: 1_000_000_000_000_000_000, // 1 reward per token.
     },
     Holder {
         token_account_balance: 10_000,
@@ -460,7 +460,7 @@ struct Holder {
 #[test_case(
     Pool {
         excess_lamports: 1_000_000,
-        accumulated_rewards_per_token: 1_000_000_000, // 1 reward per token.
+        accumulated_rewards_per_token: 1_000_000_000_000_000_000, // 1 reward per token.
     },
     Holder {
         token_account_balance: 10_000,
@@ -474,11 +474,11 @@ struct Holder {
 #[test_case(
     Pool {
         excess_lamports: 10_000,
-        accumulated_rewards_per_token: 1_000_000_000, // 1 reward per token.
+        accumulated_rewards_per_token: 1_000_000_000_000_000_000, // 1 reward per token.
     },
     Holder {
         token_account_balance: 10_000,
-        last_accumulated_rewards_per_token: 500_000_000, // 0.5 rewards per token.
+        last_accumulated_rewards_per_token: 500_000_000_000_000_000, // 0.5 rewards per token.
         unharvested_rewards: 0,
     },
     5_000, // (1 - 0.5) * 10_000
@@ -488,11 +488,11 @@ struct Holder {
 #[test_case(
     Pool {
         excess_lamports: 10_000,
-        accumulated_rewards_per_token: 1_000_000_000, // 1 reward per token.
+        accumulated_rewards_per_token: 1_000_000_000_000_000_000, // 1 reward per token.
     },
     Holder {
         token_account_balance: 10_000,
-        last_accumulated_rewards_per_token: 500_000_000, // 0.5 rewards per token.
+        last_accumulated_rewards_per_token: 500_000_000_000_000_000, // 0.5 rewards per token.
         unharvested_rewards: 1_000,
     },
     6_000, // (1 - 0.5) * 10_000 = 5_000 share + 1_000 unharvested
@@ -502,11 +502,11 @@ struct Holder {
 #[test_case(
     Pool {
         excess_lamports: 10_000,
-        accumulated_rewards_per_token: 1_000_000_000, // 1 reward per token.
+        accumulated_rewards_per_token: 1_000_000_000_000_000_000, // 1 reward per token.
     },
     Holder {
         token_account_balance: 10_000,
-        last_accumulated_rewards_per_token: 500_000_000, // 0.5 rewards per token.
+        last_accumulated_rewards_per_token: 500_000_000_000_000_000, // 0.5 rewards per token.
         unharvested_rewards: 8_000,
     },
     10_000, // Pool excess.
@@ -516,11 +516,11 @@ struct Holder {
 #[test_case(
     Pool {
         excess_lamports: 10_000,
-        accumulated_rewards_per_token: 1_000_000_000, // 1 reward per token.
+        accumulated_rewards_per_token: 1_000_000_000_000_000_000, // 1 reward per token.
     },
     Holder {
         token_account_balance: 10_000,
-        last_accumulated_rewards_per_token: 250_000_000, // 0.25 rewards per token.
+        last_accumulated_rewards_per_token: 250_000_000_000_000_000, // 0.25 rewards per token.
         unharvested_rewards: 0,
     },
     7_500, // (1 - 0.25) * 10_000
@@ -530,11 +530,11 @@ struct Holder {
 #[test_case(
     Pool {
         excess_lamports: 10_000,
-        accumulated_rewards_per_token: 1_000_000_000, // 1 reward per token.
+        accumulated_rewards_per_token: 1_000_000_000_000_000_000, // 1 reward per token.
     },
     Holder {
         token_account_balance: 10_000,
-        last_accumulated_rewards_per_token: 250_000_000, // 0.25 rewards per token.
+        last_accumulated_rewards_per_token: 250_000_000_000_000_000, // 0.25 rewards per token.
         unharvested_rewards: 1_000,
     },
     8_500, // (1 - 0.25) * 10_000 = 7_500 share + 1_000 unharvested
@@ -544,11 +544,11 @@ struct Holder {
 #[test_case(
     Pool {
         excess_lamports: 10_000,
-        accumulated_rewards_per_token: 1_000_000_000, // 1 reward per token.
+        accumulated_rewards_per_token: 1_000_000_000_000_000_000, // 1 reward per token.
     },
     Holder {
         token_account_balance: 10_000,
-        last_accumulated_rewards_per_token: 250_000_000, // 0.25 rewards per token.
+        last_accumulated_rewards_per_token: 250_000_000_000_000_000, // 0.25 rewards per token.
         unharvested_rewards: 4_000,
     },
     10_000, // Pool excess.

--- a/program/tests/transfer_hook.rs
+++ b/program/tests/transfer_hook.rs
@@ -1183,17 +1183,17 @@ async fn check_holder_rewards(
 )]
 #[test_case(
     Pool {
-        accumulated_rewards_per_token: 1_000_000_000, // 1 reward per token.
+        accumulated_rewards_per_token: 1_000_000_000_000_000_000, // 1 reward per token.
     },
     Holder {
         token_account_balance: 100,
-        last_accumulated_rewards_per_token: 1_000_000_000, // 1 reward per token.
+        last_accumulated_rewards_per_token: 1_000_000_000_000_000_000, // 1 reward per token.
         unharvested_rewards: 0,
         expected_unharvested_rewards: 0,
     },
     Holder {
         token_account_balance: 100,
-        last_accumulated_rewards_per_token: 1_000_000_000, // 1 reward per token.
+        last_accumulated_rewards_per_token: 1_000_000_000_000_000_000, // 1 reward per token.
         unharvested_rewards: 0,
         expected_unharvested_rewards: 0,
     };
@@ -1201,17 +1201,17 @@ async fn check_holder_rewards(
 )]
 #[test_case(
     Pool {
-        accumulated_rewards_per_token: 1_000_000_000, // 1 reward per token.
+        accumulated_rewards_per_token: 1_000_000_000_000_000_000, // 1 reward per token.
     },
     Holder {
         token_account_balance: 100,
-        last_accumulated_rewards_per_token: 500_000_000, // 0.5 rewards per token.
+        last_accumulated_rewards_per_token: 500_000_000_000_000_000, // 0.5 rewards per token.
         unharvested_rewards: 0,
         expected_unharvested_rewards: 50, // (1 - 0.5) * 100 = 50
     },
     Holder {
         token_account_balance: 100,
-        last_accumulated_rewards_per_token: 500_000_000, // 0.5 rewards per token.
+        last_accumulated_rewards_per_token: 500_000_000_000_000_000, // 0.5 rewards per token.
         unharvested_rewards: 0,
         expected_unharvested_rewards: 50, // (1 - 0.5) * 100 = 50
     };
@@ -1219,17 +1219,17 @@ async fn check_holder_rewards(
 )]
 #[test_case(
     Pool {
-        accumulated_rewards_per_token: 1_000_000_000, // 1 reward per token.
+        accumulated_rewards_per_token: 1_000_000_000_000_000_000, // 1 reward per token.
     },
     Holder {
         token_account_balance: 100,
-        last_accumulated_rewards_per_token: 250_000_000, // 0.25 rewards per token.
+        last_accumulated_rewards_per_token: 250_000_000_000_000_000, // 0.25 rewards per token.
         unharvested_rewards: 0,
         expected_unharvested_rewards: 75, // (1 - 0.25) * 100 = 75
     },
     Holder {
         token_account_balance: 100,
-        last_accumulated_rewards_per_token: 750_000_000, // 0.75 rewards per token.
+        last_accumulated_rewards_per_token: 750_000_000_000_000_000, // 0.75 rewards per token.
         unharvested_rewards: 0,
         expected_unharvested_rewards: 25, // (1 - 0.75) * 100 = 25
     };
@@ -1237,17 +1237,17 @@ async fn check_holder_rewards(
 )]
 #[test_case(
     Pool {
-        accumulated_rewards_per_token: 1_000_000_000, // 1 reward per token.
+        accumulated_rewards_per_token: 1_000_000_000_000_000_000, // 1 reward per token.
     },
     Holder {
         token_account_balance: 100,
-        last_accumulated_rewards_per_token: 250_000_000, // 0.25 rewards per token.
+        last_accumulated_rewards_per_token: 250_000_000_000_000_000, // 0.25 rewards per token.
         unharvested_rewards: 100,
         expected_unharvested_rewards: 175, // (1 - 0.25) * 100 + 100 = 175
     },
     Holder {
         token_account_balance: 100,
-        last_accumulated_rewards_per_token: 750_000_000, // 0.75 rewards per token.
+        last_accumulated_rewards_per_token: 750_000_000_000_000_000, // 0.75 rewards per token.
         unharvested_rewards: 0,
         expected_unharvested_rewards: 25, // (1 - 0.75) * 100 = 25
     };
@@ -1255,17 +1255,17 @@ async fn check_holder_rewards(
 )]
 #[test_case(
     Pool {
-        accumulated_rewards_per_token: 1_000_000_000, // 1 reward per token.
+        accumulated_rewards_per_token: 1_000_000_000_000_000_000, // 1 reward per token.
     },
     Holder {
         token_account_balance: 100,
-        last_accumulated_rewards_per_token: 250_000_000, // 0.25 rewards per token.
+        last_accumulated_rewards_per_token: 250_000_000_000_000_000, // 0.25 rewards per token.
         unharvested_rewards: 0,
         expected_unharvested_rewards: 75, // (1 - 0.25) * 100 = 75
     },
     Holder {
         token_account_balance: 100,
-        last_accumulated_rewards_per_token: 750_000_000, // 0.75 rewards per token.
+        last_accumulated_rewards_per_token: 750_000_000_000_000_000, // 0.75 rewards per token.
         unharvested_rewards: 200,
         expected_unharvested_rewards: 225, // (1 - 0.75) * 100 + 200 = 225
     };
@@ -1273,17 +1273,17 @@ async fn check_holder_rewards(
 )]
 #[test_case(
     Pool {
-        accumulated_rewards_per_token: 1_000_000_000, // 1 reward per token.
+        accumulated_rewards_per_token: 1_000_000_000_000_000_000, // 1 reward per token.
     },
     Holder {
         token_account_balance: 100,
-        last_accumulated_rewards_per_token: 250_000_000, // 0.25 rewards per token.
+        last_accumulated_rewards_per_token: 250_000_000_000_000_000, // 0.25 rewards per token.
         unharvested_rewards: 100,
         expected_unharvested_rewards: 175, // (1 - 0.25) * 100 + 100 = 175
     },
     Holder {
         token_account_balance: 100,
-        last_accumulated_rewards_per_token: 750_000_000, // 0.75 rewards per token.
+        last_accumulated_rewards_per_token: 750_000_000_000_000_000, // 0.75 rewards per token.
         unharvested_rewards: 200,
         expected_unharvested_rewards: 225, // (1 - 0.75) * 100 + 200 = 225
     };


### PR DESCRIPTION
#### Problem
With the program's current scaling factor for "rewards per token" of `1e9`, the minimum reward that will not cause `calculate_rewards_per_token` to return zero is 1 SOL. This is much too high, since small rewards could be paid into the system periodically.

#### Summary of Changes
Increase the scaling factor to `1e18`. This might be considered overkill, but our system can support it, and it also allows the program to capture rewards per token calculations for a minimum reward of 1 lamport.

Consider the formula for `calculate_rewards_per_token`:

https://github.com/paladin-bladesmith/rewards-program/blob/6e7fd604c0c543889d746bde0b791209a22a9e5f/program/src/processor.rs#L130-L138

The formula requires that the reward multiplied by the scaling factor does not exceed `u128::MAX`. That means the largest scaling factor we can use is `u128::MAX / u64::MAX`, which is `1.845 * e19`. I've selected `1e18` since it's within our bound and we cannot have below 1 lamport as a reward, since `u64` is an unsigned whole integer.

---

Increasing the scaling to `1e18` does reduce the upper bound of the maximum marginal rate, since within `calculate_eligible_rewards`, we are multiplying the marginal rate by the token account balance. This will be handled in a follow-up PR, where we'll change the checked math to wrapped math.