### PR TITLE
Processor: Use wrapped math

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,13 @@ and her token balance has not changed, she is now eligible for 3 rewards per
 token - the difference between the current accumulated rate, and the rate she
 last harvested at.
 
+Note: Rewards per token are scaled by `1e18` to account for 18 decimals of
+precision. This means the values for accumulated rewards per token will be
+quite large. The calculation of eligible rewards based on the "last seen"
+rewards per token and the _current_ rewards per token, as well as the
+incrementing of this rate in the processor, use **wrapping math**, so overflow
+is handled gracefully. For more information, see `processor.rs`.
+
 ## Transfer Hook
 
 The Paladin Rewards program also implements the SPL Transfer Hook interface,

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -766,7 +766,7 @@ mod tests {
     fn wrapping_eligible_rewards() {
         // Set up current to be less than rate, simulating a scenario where the
         // current reward has wrapped around `u128::MAX`.
-        let current_accumulated_rewards_per_token = 1_000_000_000_000_000_000;
+        let current_accumulated_rewards_per_token = 0;
         let last_accumulated_rewards_per_token = u128::MAX - 1_000_000_000_000_000_000;
         let result = calculate_eligible_rewards(
             current_accumulated_rewards_per_token,
@@ -774,7 +774,7 @@ mod tests {
             BENCH_TOKEN_SUPPLY,
         )
         .unwrap();
-        assert_ne!(result, 1_000_000_000_000_000_000);
+        assert_eq!(result, 1_000_000_000_000_000_001);
 
         // Try it again at the very edge. Result should be one.
         let current_accumulated_rewards_per_token = 0;

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -143,14 +143,10 @@ fn calculate_rewards_per_token(rewards: u64, token_supply: u64) -> Result<u128, 
 // The result is descaled by a factor of 1e18 since both rewards per token
 // values are scaled by 1e18 for precision.
 //
-// This calculation is valid under the following conditions:
-// * The current accumulated rewards per token is always greater than or equal
-//   to the last accumulated rewards per token.
-// * The total rewards accumulated by the system does not exceed `u64::MAX`.
+// This calculation is valid as long as the total rewards accumulated by the
+// system does not exceed `u64::MAX`.
 //
-// The first condition is guaranteed by the program logic.
-//
-// The second condition is a reasonable upper bound, considering `u64::MAX` is
+// This condition is a reasonable upper bound, considering `u64::MAX` is
 // approximately 386_266 % of the current circulating supply of SOL.
 //
 // For more information, see this function's prop tests.
@@ -159,9 +155,8 @@ fn calculate_eligible_rewards(
     last_accumulated_rewards_per_token: u128,
     token_account_balance: u64,
 ) -> Result<u64, ProgramError> {
-    let marginal_rate = current_accumulated_rewards_per_token
-        .checked_sub(last_accumulated_rewards_per_token)
-        .ok_or(ProgramError::ArithmeticOverflow)?;
+    let marginal_rate =
+        current_accumulated_rewards_per_token.wrapping_sub(last_accumulated_rewards_per_token);
     if marginal_rate == 0 {
         return Ok(0);
     }
@@ -392,8 +387,7 @@ fn process_distribute_rewards(
         let marginal_rate = calculate_rewards_per_token(amount, token_supply)?;
         let new_accumulated_rewards_per_token = pool_state
             .accumulated_rewards_per_token
-            .checked_add(marginal_rate)
-            .ok_or(ProgramError::ArithmeticOverflow)?;
+            .wrapping_add(marginal_rate);
 
         pool_state.accumulated_rewards_per_token = new_accumulated_rewards_per_token;
     }

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -762,6 +762,32 @@ mod tests {
         .unwrap();
     }
 
+    #[test]
+    fn wrapping_eligible_rewards() {
+        // Set up current to be less than rate, simulating a scenario where the
+        // current reward has wrapped around `u128::MAX`.
+        let current_accumulated_rewards_per_token = 1_000_000_000_000_000_000;
+        let last_accumulated_rewards_per_token = u128::MAX - 1_000_000_000_000_000_000;
+        let result = calculate_eligible_rewards(
+            current_accumulated_rewards_per_token,
+            last_accumulated_rewards_per_token,
+            BENCH_TOKEN_SUPPLY,
+        )
+        .unwrap();
+        assert_ne!(result, 1_000_000_000_000_000_000);
+
+        // Try it again at the very edge. Result should be one.
+        let current_accumulated_rewards_per_token = 0;
+        let last_accumulated_rewards_per_token = u128::MAX;
+        let result = calculate_eligible_rewards(
+            current_accumulated_rewards_per_token,
+            last_accumulated_rewards_per_token,
+            BENCH_TOKEN_SUPPLY,
+        )
+        .unwrap();
+        assert_eq!(result, 1);
+    }
+
     proptest! {
         #[test]
         fn test_calculate_rewards_per_token(

--- a/program/tests/distribute_rewards.rs
+++ b/program/tests/distribute_rewards.rs
@@ -333,6 +333,17 @@ struct ExpectedPool {
     125_000;
     "50% initial rate, rewards increase by 250%, resulting rate 175%"
 )]
+#[test_case(
+    InitialPool {
+        token_supply: 100_000,
+        accumulated_rewards_per_token: u128::MAX,
+    },
+    ExpectedPool {
+        accumulated_rewards_per_token: 1_250_000_000_000_000_000 - 1, // Wrapped.
+    },
+    125_000;
+    "maximum initial rate, rewards increase, resulting rate should be wrapped"
+)]
 #[tokio::test]
 async fn success(initial: InitialPool, expected: ExpectedPool, reward_amount: u64) {
     let InitialPool {

--- a/program/tests/harvest_rewards.rs
+++ b/program/tests/harvest_rewards.rs
@@ -488,6 +488,20 @@ struct Holder {
 #[test_case(
     Pool {
         excess_lamports: 10_000,
+        accumulated_rewards_per_token: 1_000_000_000_000_000_000 - 1, // Just below 1 reward per token.
+    },
+    Holder {
+        token_account_balance: 10_000,
+        last_accumulated_rewards_per_token: u128::MAX, // Maximum rate.
+        unharvested_rewards: 0,
+    },
+    10_000, // 1 * 10_000
+    0;
+    "Last harvested maximum rate, eligible for 1 rate, pool has enough, receive share"
+)]
+#[test_case(
+    Pool {
+        excess_lamports: 10_000,
         accumulated_rewards_per_token: 1_000_000_000_000_000_000, // 1 reward per token.
     },
     Holder {
@@ -554,6 +568,20 @@ struct Holder {
     10_000, // Pool excess.
     1_500; // 10_000 pool excess - [(1 - 0.25) * 10_000 = 7_500 share + 4_000 unharvested]
     "Last harvested 0.25 rate, some unharvested, eligible for 0.75 rate, pool underfunded, receive pool excess"
+)]
+#[test_case(
+    Pool {
+        excess_lamports: 11_000,
+        accumulated_rewards_per_token: 1_000_000_000_000_000_000 - 1, // Just below 1 reward per token.
+    },
+    Holder {
+        token_account_balance: 10_000,
+        last_accumulated_rewards_per_token: u128::MAX, // Maximum rate.
+        unharvested_rewards: 1_000,
+    },
+    11_000, // 1 * 10_000 = 10_000 share + 1_000 unharvested
+    0;
+    "Last harvested maximum rate, some unharvested, eligible for 1 rate, pool has enough, receive share + unharvested"
 )]
 #[tokio::test]
 async fn success(


### PR DESCRIPTION
#### Problem
Whenever the reward system's "accumulated rewards per token" reaches a value of `u128::MAX`, the system would break and no longer accept any additional rewards paid in. Since we've increased the scaling factor to `1e18`, the total system-level rewards paid in over time that would break the system is `u128::MAX`.

Although this is a pretty large upper bound, we can further increase the system's robustness by using wrapped math for incrementing "accumulated rewards per token" as well as calculating eligible rewards.

#### Summary of Changes
Use wrapped math instead of checked math for incrementing "accumulated rewards per token" as well as calculating eligible rewards.