### PR TITLE
Processor: Adjust handling of zero rewards to harvest

### DIFF
--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -515,15 +515,17 @@ fn process_harvest_rewards(program_id: &Pubkey, accounts: &[AccountInfo]) -> Pro
             token_account_balance,
         )?;
 
-        // Update the holder rewards state.
-        //
-        // Temporarily update `unharvested_rewards` with the eligible rewards.
-        holder_rewards_state.last_accumulated_rewards_per_token =
-            pool_state.accumulated_rewards_per_token;
-        holder_rewards_state.unharvested_rewards = holder_rewards_state
-            .unharvested_rewards
-            .checked_add(eligible_rewards)
-            .ok_or(ProgramError::ArithmeticOverflow)?;
+        if eligible_rewards != 0 {
+            // Update the holder rewards state.
+            //
+            // Temporarily update `unharvested_rewards` with the eligible rewards.
+            holder_rewards_state.last_accumulated_rewards_per_token =
+                pool_state.accumulated_rewards_per_token;
+            holder_rewards_state.unharvested_rewards = holder_rewards_state
+                .unharvested_rewards
+                .checked_add(eligible_rewards)
+                .ok_or(ProgramError::ArithmeticOverflow)?;
+        }
 
         // If the pool doesn't have enough lamports to cover the rewards, only
         // harvest the available lamports. This should never happen, but the check

--- a/program/tests/e2e.rs
+++ b/program/tests/e2e.rs
@@ -1086,7 +1086,7 @@ async fn test_e2e() {
                     &carol_token_account,
                     Holder {
                         token_account_balance: 0,
-                        last_accumulated_rewards_per_token: 6_000_000_000_000_000_000,
+                        last_accumulated_rewards_per_token: 3_000_000_000_000_000_000,
                         unharvested_rewards: 0,
                     },
                 ),


### PR DESCRIPTION
#### Problem
When a holder has no rewards to harvest, the program should ensure that their marginal rate (the current rewards per token minus their last seen rewards per token) is not diminished by attempting to harvest when they are not eligible for any rewards yet. This can occur when the marginal rate is too small to resolve to at least one lamport in eligible rewards.

This behavior also can occur on transfer hook, where eligible rewards are moved to unharvested.

#### Summary of Changes
Ensures the last seen rate is only updated when eligible rewards is non-zero, for both harvest and transfer hook.