### PR TITLE
fix: add amount to withdraw

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2686,6 +2686,7 @@ dependencies = [
  "bytemuck",
  "num-derive 0.3.3",
  "num-traits",
+ "paladin-rewards-program-client",
  "proptest",
  "shank",
  "solana-program",

--- a/clients/js/src/generated/errors/paladinRewards.ts
+++ b/clients/js/src/generated/errors/paladinRewards.ts
@@ -42,6 +42,8 @@ export const PALADIN_REWARDS_ERROR__TOKEN_ACCOUNT_OWNER_MISSMATCH = 0xb; // 11
 export const PALADIN_REWARDS_ERROR__TOKEN_ACCOUNT_FROZEN = 0xc; // 12
 /** NotEnoughTokenToDeposit: Owner doesn'thave enough tokens to deposit */
 export const PALADIN_REWARDS_ERROR__NOT_ENOUGH_TOKEN_TO_DEPOSIT = 0xd; // 13
+/** WithdrawExceedsDeposited: Withdraw amount exceeds deposited */
+export const PALADIN_REWARDS_ERROR__WITHDRAW_EXCEEDS_DEPOSITED = 0xe; // 14
 
 export type PaladinRewardsError =
   | typeof PALADIN_REWARDS_ERROR__CLOSE_WITH_DEPOSITED_TOKENS
@@ -57,6 +59,7 @@ export type PaladinRewardsError =
   | typeof PALADIN_REWARDS_ERROR__TOKEN_ACCOUNT_FROZEN
   | typeof PALADIN_REWARDS_ERROR__TOKEN_ACCOUNT_MINT_MISMATCH
   | typeof PALADIN_REWARDS_ERROR__TOKEN_ACCOUNT_OWNER_MISSMATCH
+  | typeof PALADIN_REWARDS_ERROR__WITHDRAW_EXCEEDS_DEPOSITED
   | typeof PALADIN_REWARDS_ERROR__WITHDRAW_EXCEEDS_POOL_BALANCE;
 
 let paladinRewardsErrorMessages:
@@ -77,6 +80,7 @@ if (process.env.NODE_ENV !== 'production') {
     [PALADIN_REWARDS_ERROR__TOKEN_ACCOUNT_FROZEN]: `Token account is frozen`,
     [PALADIN_REWARDS_ERROR__TOKEN_ACCOUNT_MINT_MISMATCH]: `Token account mint mismatch`,
     [PALADIN_REWARDS_ERROR__TOKEN_ACCOUNT_OWNER_MISSMATCH]: `Token account owner mismatch`,
+    [PALADIN_REWARDS_ERROR__WITHDRAW_EXCEEDS_DEPOSITED]: `Withdraw amount exceeds deposited`,
     [PALADIN_REWARDS_ERROR__WITHDRAW_EXCEEDS_POOL_BALANCE]: `Pool doesn't have enough balance to withdraw`,
   };
 }

--- a/clients/js/src/generated/instructions/closeHolderRewards.ts
+++ b/clients/js/src/generated/instructions/closeHolderRewards.ts
@@ -30,14 +30,19 @@ import {
 import { PALADIN_REWARDS_PROGRAM_ADDRESS } from '../programs';
 import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
 
+export const CLOSE_HOLDER_REWARDS_DISCRIMINATOR = 3;
+
+export function getCloseHolderRewardsDiscriminatorBytes() {
+  return getU8Encoder().encode(CLOSE_HOLDER_REWARDS_DISCRIMINATOR);
+}
+
 export type CloseHolderRewardsInstruction<
   TProgram extends string = typeof PALADIN_REWARDS_PROGRAM_ADDRESS,
   TAccountHolderRewardsPool extends string | IAccountMeta<string> = string,
-  TAccountHolderRewardsPoolTokenAccountInfo extends
+  TAccountHolderRewardsPoolTokenAccount extends
     | string
     | IAccountMeta<string> = string,
   TAccountHolderRewards extends string | IAccountMeta<string> = string,
-  TAccountTokenAccount extends string | IAccountMeta<string> = string,
   TAccountMint extends string | IAccountMeta<string> = string,
   TAccountOwner extends string | IAccountMeta<string> = string,
   TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
@@ -48,15 +53,12 @@ export type CloseHolderRewardsInstruction<
       TAccountHolderRewardsPool extends string
         ? WritableAccount<TAccountHolderRewardsPool>
         : TAccountHolderRewardsPool,
-      TAccountHolderRewardsPoolTokenAccountInfo extends string
-        ? WritableAccount<TAccountHolderRewardsPoolTokenAccountInfo>
-        : TAccountHolderRewardsPoolTokenAccountInfo,
+      TAccountHolderRewardsPoolTokenAccount extends string
+        ? WritableAccount<TAccountHolderRewardsPoolTokenAccount>
+        : TAccountHolderRewardsPoolTokenAccount,
       TAccountHolderRewards extends string
         ? WritableAccount<TAccountHolderRewards>
         : TAccountHolderRewards,
-      TAccountTokenAccount extends string
-        ? ReadonlyAccount<TAccountTokenAccount>
-        : TAccountTokenAccount,
       TAccountMint extends string
         ? ReadonlyAccount<TAccountMint>
         : TAccountMint,
@@ -75,7 +77,7 @@ export type CloseHolderRewardsInstructionDataArgs = {};
 export function getCloseHolderRewardsInstructionDataEncoder(): Encoder<CloseHolderRewardsInstructionDataArgs> {
   return transformEncoder(
     getStructEncoder([['discriminator', getU8Encoder()]]),
-    (value) => ({ ...value, discriminator: 3 })
+    (value) => ({ ...value, discriminator: CLOSE_HOLDER_REWARDS_DISCRIMINATOR })
   );
 }
 
@@ -95,20 +97,17 @@ export function getCloseHolderRewardsInstructionDataCodec(): Codec<
 
 export type CloseHolderRewardsInput<
   TAccountHolderRewardsPool extends string = string,
-  TAccountHolderRewardsPoolTokenAccountInfo extends string = string,
+  TAccountHolderRewardsPoolTokenAccount extends string = string,
   TAccountHolderRewards extends string = string,
-  TAccountTokenAccount extends string = string,
   TAccountMint extends string = string,
   TAccountOwner extends string = string,
 > = {
   /** Holder rewards pool account. */
   holderRewardsPool: Address<TAccountHolderRewardsPool>;
   /** Holder rewards pool token account. */
-  holderRewardsPoolTokenAccountInfo: Address<TAccountHolderRewardsPoolTokenAccountInfo>;
+  holderRewardsPoolTokenAccount: Address<TAccountHolderRewardsPoolTokenAccount>;
   /** Holder rewards account. */
   holderRewards: Address<TAccountHolderRewards>;
-  /** Token account. */
-  tokenAccount: Address<TAccountTokenAccount>;
   /** Token mint. */
   mint: Address<TAccountMint>;
   /** Owner of the account. */
@@ -117,31 +116,31 @@ export type CloseHolderRewardsInput<
 
 export function getCloseHolderRewardsInstruction<
   TAccountHolderRewardsPool extends string,
-  TAccountHolderRewardsPoolTokenAccountInfo extends string,
+  TAccountHolderRewardsPoolTokenAccount extends string,
   TAccountHolderRewards extends string,
-  TAccountTokenAccount extends string,
   TAccountMint extends string,
   TAccountOwner extends string,
+  TProgramAddress extends Address = typeof PALADIN_REWARDS_PROGRAM_ADDRESS,
 >(
   input: CloseHolderRewardsInput<
     TAccountHolderRewardsPool,
-    TAccountHolderRewardsPoolTokenAccountInfo,
+    TAccountHolderRewardsPoolTokenAccount,
     TAccountHolderRewards,
-    TAccountTokenAccount,
     TAccountMint,
     TAccountOwner
-  >
+  >,
+  config?: { programAddress?: TProgramAddress }
 ): CloseHolderRewardsInstruction<
-  typeof PALADIN_REWARDS_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountHolderRewardsPool,
-  TAccountHolderRewardsPoolTokenAccountInfo,
+  TAccountHolderRewardsPoolTokenAccount,
   TAccountHolderRewards,
-  TAccountTokenAccount,
   TAccountMint,
   TAccountOwner
 > {
   // Program address.
-  const programAddress = PALADIN_REWARDS_PROGRAM_ADDRESS;
+  const programAddress =
+    config?.programAddress ?? PALADIN_REWARDS_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -149,12 +148,11 @@ export function getCloseHolderRewardsInstruction<
       value: input.holderRewardsPool ?? null,
       isWritable: true,
     },
-    holderRewardsPoolTokenAccountInfo: {
-      value: input.holderRewardsPoolTokenAccountInfo ?? null,
+    holderRewardsPoolTokenAccount: {
+      value: input.holderRewardsPoolTokenAccount ?? null,
       isWritable: true,
     },
     holderRewards: { value: input.holderRewards ?? null, isWritable: true },
-    tokenAccount: { value: input.tokenAccount ?? null, isWritable: false },
     mint: { value: input.mint ?? null, isWritable: false },
     owner: { value: input.owner ?? null, isWritable: true },
   };
@@ -167,20 +165,18 @@ export function getCloseHolderRewardsInstruction<
   const instruction = {
     accounts: [
       getAccountMeta(accounts.holderRewardsPool),
-      getAccountMeta(accounts.holderRewardsPoolTokenAccountInfo),
+      getAccountMeta(accounts.holderRewardsPoolTokenAccount),
       getAccountMeta(accounts.holderRewards),
-      getAccountMeta(accounts.tokenAccount),
       getAccountMeta(accounts.mint),
       getAccountMeta(accounts.owner),
     ],
     programAddress,
     data: getCloseHolderRewardsInstructionDataEncoder().encode({}),
   } as CloseHolderRewardsInstruction<
-    typeof PALADIN_REWARDS_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountHolderRewardsPool,
-    TAccountHolderRewardsPoolTokenAccountInfo,
+    TAccountHolderRewardsPoolTokenAccount,
     TAccountHolderRewards,
-    TAccountTokenAccount,
     TAccountMint,
     TAccountOwner
   >;
@@ -197,15 +193,13 @@ export type ParsedCloseHolderRewardsInstruction<
     /** Holder rewards pool account. */
     holderRewardsPool: TAccountMetas[0];
     /** Holder rewards pool token account. */
-    holderRewardsPoolTokenAccountInfo: TAccountMetas[1];
+    holderRewardsPoolTokenAccount: TAccountMetas[1];
     /** Holder rewards account. */
     holderRewards: TAccountMetas[2];
-    /** Token account. */
-    tokenAccount: TAccountMetas[3];
     /** Token mint. */
-    mint: TAccountMetas[4];
+    mint: TAccountMetas[3];
     /** Owner of the account. */
-    owner: TAccountMetas[5];
+    owner: TAccountMetas[4];
   };
   data: CloseHolderRewardsInstructionData;
 };
@@ -218,7 +212,7 @@ export function parseCloseHolderRewardsInstruction<
     IInstructionWithAccounts<TAccountMetas> &
     IInstructionWithData<Uint8Array>
 ): ParsedCloseHolderRewardsInstruction<TProgram, TAccountMetas> {
-  if (instruction.accounts.length < 6) {
+  if (instruction.accounts.length < 5) {
     // TODO: Coded error.
     throw new Error('Not enough accounts');
   }
@@ -232,9 +226,8 @@ export function parseCloseHolderRewardsInstruction<
     programAddress: instruction.programAddress,
     accounts: {
       holderRewardsPool: getNextAccount(),
-      holderRewardsPoolTokenAccountInfo: getNextAccount(),
+      holderRewardsPoolTokenAccount: getNextAccount(),
       holderRewards: getNextAccount(),
-      tokenAccount: getNextAccount(),
       mint: getNextAccount(),
       owner: getNextAccount(),
     },

--- a/clients/js/src/generated/instructions/deposit.ts
+++ b/clients/js/src/generated/instructions/deposit.ts
@@ -25,12 +25,18 @@ import {
   type IInstructionWithAccounts,
   type IInstructionWithData,
   type ReadonlyAccount,
-  type ReadonlySignerAccount,
   type TransactionSigner,
   type WritableAccount,
+  type WritableSignerAccount,
 } from '@solana/web3.js';
 import { PALADIN_REWARDS_PROGRAM_ADDRESS } from '../programs';
 import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
+
+export const DEPOSIT_DISCRIMINATOR = 4;
+
+export function getDepositDiscriminatorBytes() {
+  return getU8Encoder().encode(DEPOSIT_DISCRIMINATOR);
+}
 
 export type DepositInstruction<
   TProgram extends string = typeof PALADIN_REWARDS_PROGRAM_ADDRESS,
@@ -66,7 +72,7 @@ export type DepositInstruction<
         ? ReadonlyAccount<TAccountMint>
         : TAccountMint,
       TAccountOwner extends string
-        ? ReadonlySignerAccount<TAccountOwner> &
+        ? WritableSignerAccount<TAccountOwner> &
             IAccountSignerMeta<TAccountOwner>
         : TAccountOwner,
       TAccountTokenProgram extends string
@@ -86,7 +92,7 @@ export function getDepositInstructionDataEncoder(): Encoder<DepositInstructionDa
       ['discriminator', getU8Encoder()],
       ['amount', getU64Encoder()],
     ]),
-    (value) => ({ ...value, discriminator: 4 })
+    (value) => ({ ...value, discriminator: DEPOSIT_DISCRIMINATOR })
   );
 }
 
@@ -141,6 +147,7 @@ export function getDepositInstruction<
   TAccountMint extends string,
   TAccountOwner extends string,
   TAccountTokenProgram extends string,
+  TProgramAddress extends Address = typeof PALADIN_REWARDS_PROGRAM_ADDRESS,
 >(
   input: DepositInput<
     TAccountHolderRewardsPool,
@@ -150,9 +157,10 @@ export function getDepositInstruction<
     TAccountMint,
     TAccountOwner,
     TAccountTokenProgram
-  >
+  >,
+  config?: { programAddress?: TProgramAddress }
 ): DepositInstruction<
-  typeof PALADIN_REWARDS_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountHolderRewardsPool,
   TAccountHolderRewardsPoolTokenAccount,
   TAccountHolderRewards,
@@ -162,7 +170,8 @@ export function getDepositInstruction<
   TAccountTokenProgram
 > {
   // Program address.
-  const programAddress = PALADIN_REWARDS_PROGRAM_ADDRESS;
+  const programAddress =
+    config?.programAddress ?? PALADIN_REWARDS_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -177,7 +186,7 @@ export function getDepositInstruction<
     holderRewards: { value: input.holderRewards ?? null, isWritable: true },
     tokenAccount: { value: input.tokenAccount ?? null, isWritable: true },
     mint: { value: input.mint ?? null, isWritable: false },
-    owner: { value: input.owner ?? null, isWritable: false },
+    owner: { value: input.owner ?? null, isWritable: true },
     tokenProgram: { value: input.tokenProgram ?? null, isWritable: false },
   };
   const accounts = originalAccounts as Record<
@@ -210,7 +219,7 @@ export function getDepositInstruction<
       args as DepositInstructionDataArgs
     ),
   } as DepositInstruction<
-    typeof PALADIN_REWARDS_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountHolderRewardsPool,
     TAccountHolderRewardsPoolTokenAccount,
     TAccountHolderRewards,

--- a/clients/js/src/generated/instructions/deposit.ts
+++ b/clients/js/src/generated/instructions/deposit.ts
@@ -54,7 +54,7 @@ export type DepositInstruction<
         ? WritableAccount<TAccountHolderRewardsPool>
         : TAccountHolderRewardsPool,
       TAccountHolderRewardsPoolTokenAccount extends string
-        ? ReadonlyAccount<TAccountHolderRewardsPoolTokenAccount>
+        ? WritableAccount<TAccountHolderRewardsPoolTokenAccount>
         : TAccountHolderRewardsPoolTokenAccount,
       TAccountHolderRewards extends string
         ? WritableAccount<TAccountHolderRewards>
@@ -172,7 +172,7 @@ export function getDepositInstruction<
     },
     holderRewardsPoolTokenAccount: {
       value: input.holderRewardsPoolTokenAccount ?? null,
-      isWritable: false,
+      isWritable: true,
     },
     holderRewards: { value: input.holderRewards ?? null, isWritable: true },
     tokenAccount: { value: input.tokenAccount ?? null, isWritable: true },

--- a/clients/js/src/generated/instructions/harvestRewards.ts
+++ b/clients/js/src/generated/instructions/harvestRewards.ts
@@ -30,10 +30,16 @@ import {
 import { PALADIN_REWARDS_PROGRAM_ADDRESS } from '../programs';
 import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
 
+export const HARVEST_REWARDS_DISCRIMINATOR = 2;
+
+export function getHarvestRewardsDiscriminatorBytes() {
+  return getU8Encoder().encode(HARVEST_REWARDS_DISCRIMINATOR);
+}
+
 export type HarvestRewardsInstruction<
   TProgram extends string = typeof PALADIN_REWARDS_PROGRAM_ADDRESS,
   TAccountHolderRewardsPool extends string | IAccountMeta<string> = string,
-  TAccountHolderRewardsPoolTokenAccountInfo extends
+  TAccountHolderRewardsPoolTokenAccount extends
     | string
     | IAccountMeta<string> = string,
   TAccountHolderRewards extends string | IAccountMeta<string> = string,
@@ -47,9 +53,9 @@ export type HarvestRewardsInstruction<
       TAccountHolderRewardsPool extends string
         ? WritableAccount<TAccountHolderRewardsPool>
         : TAccountHolderRewardsPool,
-      TAccountHolderRewardsPoolTokenAccountInfo extends string
-        ? ReadonlyAccount<TAccountHolderRewardsPoolTokenAccountInfo>
-        : TAccountHolderRewardsPoolTokenAccountInfo,
+      TAccountHolderRewardsPoolTokenAccount extends string
+        ? ReadonlyAccount<TAccountHolderRewardsPoolTokenAccount>
+        : TAccountHolderRewardsPoolTokenAccount,
       TAccountHolderRewards extends string
         ? WritableAccount<TAccountHolderRewards>
         : TAccountHolderRewards,
@@ -71,7 +77,7 @@ export type HarvestRewardsInstructionDataArgs = {};
 export function getHarvestRewardsInstructionDataEncoder(): Encoder<HarvestRewardsInstructionDataArgs> {
   return transformEncoder(
     getStructEncoder([['discriminator', getU8Encoder()]]),
-    (value) => ({ ...value, discriminator: 2 })
+    (value) => ({ ...value, discriminator: HARVEST_REWARDS_DISCRIMINATOR })
   );
 }
 
@@ -91,7 +97,7 @@ export function getHarvestRewardsInstructionDataCodec(): Codec<
 
 export type HarvestRewardsInput<
   TAccountHolderRewardsPool extends string = string,
-  TAccountHolderRewardsPoolTokenAccountInfo extends string = string,
+  TAccountHolderRewardsPoolTokenAccount extends string = string,
   TAccountHolderRewards extends string = string,
   TAccountMint extends string = string,
   TAccountOwner extends string = string,
@@ -99,7 +105,7 @@ export type HarvestRewardsInput<
   /** Holder rewards pool account. */
   holderRewardsPool: Address<TAccountHolderRewardsPool>;
   /** Holder rewards pool token account. */
-  holderRewardsPoolTokenAccountInfo: Address<TAccountHolderRewardsPoolTokenAccountInfo>;
+  holderRewardsPoolTokenAccount: Address<TAccountHolderRewardsPoolTokenAccount>;
   /** Holder rewards account. */
   holderRewards: Address<TAccountHolderRewards>;
   /** Token mint. */
@@ -110,28 +116,31 @@ export type HarvestRewardsInput<
 
 export function getHarvestRewardsInstruction<
   TAccountHolderRewardsPool extends string,
-  TAccountHolderRewardsPoolTokenAccountInfo extends string,
+  TAccountHolderRewardsPoolTokenAccount extends string,
   TAccountHolderRewards extends string,
   TAccountMint extends string,
   TAccountOwner extends string,
+  TProgramAddress extends Address = typeof PALADIN_REWARDS_PROGRAM_ADDRESS,
 >(
   input: HarvestRewardsInput<
     TAccountHolderRewardsPool,
-    TAccountHolderRewardsPoolTokenAccountInfo,
+    TAccountHolderRewardsPoolTokenAccount,
     TAccountHolderRewards,
     TAccountMint,
     TAccountOwner
-  >
+  >,
+  config?: { programAddress?: TProgramAddress }
 ): HarvestRewardsInstruction<
-  typeof PALADIN_REWARDS_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountHolderRewardsPool,
-  TAccountHolderRewardsPoolTokenAccountInfo,
+  TAccountHolderRewardsPoolTokenAccount,
   TAccountHolderRewards,
   TAccountMint,
   TAccountOwner
 > {
   // Program address.
-  const programAddress = PALADIN_REWARDS_PROGRAM_ADDRESS;
+  const programAddress =
+    config?.programAddress ?? PALADIN_REWARDS_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -139,8 +148,8 @@ export function getHarvestRewardsInstruction<
       value: input.holderRewardsPool ?? null,
       isWritable: true,
     },
-    holderRewardsPoolTokenAccountInfo: {
-      value: input.holderRewardsPoolTokenAccountInfo ?? null,
+    holderRewardsPoolTokenAccount: {
+      value: input.holderRewardsPoolTokenAccount ?? null,
       isWritable: false,
     },
     holderRewards: { value: input.holderRewards ?? null, isWritable: true },
@@ -156,7 +165,7 @@ export function getHarvestRewardsInstruction<
   const instruction = {
     accounts: [
       getAccountMeta(accounts.holderRewardsPool),
-      getAccountMeta(accounts.holderRewardsPoolTokenAccountInfo),
+      getAccountMeta(accounts.holderRewardsPoolTokenAccount),
       getAccountMeta(accounts.holderRewards),
       getAccountMeta(accounts.mint),
       getAccountMeta(accounts.owner),
@@ -164,9 +173,9 @@ export function getHarvestRewardsInstruction<
     programAddress,
     data: getHarvestRewardsInstructionDataEncoder().encode({}),
   } as HarvestRewardsInstruction<
-    typeof PALADIN_REWARDS_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountHolderRewardsPool,
-    TAccountHolderRewardsPoolTokenAccountInfo,
+    TAccountHolderRewardsPoolTokenAccount,
     TAccountHolderRewards,
     TAccountMint,
     TAccountOwner
@@ -184,7 +193,7 @@ export type ParsedHarvestRewardsInstruction<
     /** Holder rewards pool account. */
     holderRewardsPool: TAccountMetas[0];
     /** Holder rewards pool token account. */
-    holderRewardsPoolTokenAccountInfo: TAccountMetas[1];
+    holderRewardsPoolTokenAccount: TAccountMetas[1];
     /** Holder rewards account. */
     holderRewards: TAccountMetas[2];
     /** Token mint. */
@@ -217,7 +226,7 @@ export function parseHarvestRewardsInstruction<
     programAddress: instruction.programAddress,
     accounts: {
       holderRewardsPool: getNextAccount(),
-      holderRewardsPoolTokenAccountInfo: getNextAccount(),
+      holderRewardsPoolTokenAccount: getNextAccount(),
       holderRewards: getNextAccount(),
       mint: getNextAccount(),
       owner: getNextAccount(),

--- a/clients/js/src/generated/instructions/initializeHolderRewards.ts
+++ b/clients/js/src/generated/instructions/initializeHolderRewards.ts
@@ -30,10 +30,16 @@ import {
 import { PALADIN_REWARDS_PROGRAM_ADDRESS } from '../programs';
 import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
 
+export const INITIALIZE_HOLDER_REWARDS_DISCRIMINATOR = 1;
+
+export function getInitializeHolderRewardsDiscriminatorBytes() {
+  return getU8Encoder().encode(INITIALIZE_HOLDER_REWARDS_DISCRIMINATOR);
+}
+
 export type InitializeHolderRewardsInstruction<
   TProgram extends string = typeof PALADIN_REWARDS_PROGRAM_ADDRESS,
   TAccountHolderRewardsPool extends string | IAccountMeta<string> = string,
-  TAccountHolderRewardsPoolTokenAccountInfo extends
+  TAccountHolderRewardsPoolTokenAccount extends
     | string
     | IAccountMeta<string> = string,
   TAccountOwner extends string | IAccountMeta<string> = string,
@@ -50,9 +56,9 @@ export type InitializeHolderRewardsInstruction<
       TAccountHolderRewardsPool extends string
         ? WritableAccount<TAccountHolderRewardsPool>
         : TAccountHolderRewardsPool,
-      TAccountHolderRewardsPoolTokenAccountInfo extends string
-        ? ReadonlyAccount<TAccountHolderRewardsPoolTokenAccountInfo>
-        : TAccountHolderRewardsPoolTokenAccountInfo,
+      TAccountHolderRewardsPoolTokenAccount extends string
+        ? ReadonlyAccount<TAccountHolderRewardsPoolTokenAccount>
+        : TAccountHolderRewardsPoolTokenAccount,
       TAccountOwner extends string
         ? WritableSignerAccount<TAccountOwner> &
             IAccountSignerMeta<TAccountOwner>
@@ -77,7 +83,10 @@ export type InitializeHolderRewardsInstructionDataArgs = {};
 export function getInitializeHolderRewardsInstructionDataEncoder(): Encoder<InitializeHolderRewardsInstructionDataArgs> {
   return transformEncoder(
     getStructEncoder([['discriminator', getU8Encoder()]]),
-    (value) => ({ ...value, discriminator: 1 })
+    (value) => ({
+      ...value,
+      discriminator: INITIALIZE_HOLDER_REWARDS_DISCRIMINATOR,
+    })
   );
 }
 
@@ -97,7 +106,7 @@ export function getInitializeHolderRewardsInstructionDataCodec(): Codec<
 
 export type InitializeHolderRewardsInput<
   TAccountHolderRewardsPool extends string = string,
-  TAccountHolderRewardsPoolTokenAccountInfo extends string = string,
+  TAccountHolderRewardsPoolTokenAccount extends string = string,
   TAccountOwner extends string = string,
   TAccountHolderRewards extends string = string,
   TAccountMint extends string = string,
@@ -106,7 +115,7 @@ export type InitializeHolderRewardsInput<
   /** Holder rewards pool account. */
   holderRewardsPool: Address<TAccountHolderRewardsPool>;
   /** Holder rewards pool token account. */
-  holderRewardsPoolTokenAccountInfo: Address<TAccountHolderRewardsPoolTokenAccountInfo>;
+  holderRewardsPoolTokenAccount: Address<TAccountHolderRewardsPoolTokenAccount>;
   /** Token account owner. */
   owner: TransactionSigner<TAccountOwner>;
   /** Holder rewards account. */
@@ -119,31 +128,34 @@ export type InitializeHolderRewardsInput<
 
 export function getInitializeHolderRewardsInstruction<
   TAccountHolderRewardsPool extends string,
-  TAccountHolderRewardsPoolTokenAccountInfo extends string,
+  TAccountHolderRewardsPoolTokenAccount extends string,
   TAccountOwner extends string,
   TAccountHolderRewards extends string,
   TAccountMint extends string,
   TAccountSystemProgram extends string,
+  TProgramAddress extends Address = typeof PALADIN_REWARDS_PROGRAM_ADDRESS,
 >(
   input: InitializeHolderRewardsInput<
     TAccountHolderRewardsPool,
-    TAccountHolderRewardsPoolTokenAccountInfo,
+    TAccountHolderRewardsPoolTokenAccount,
     TAccountOwner,
     TAccountHolderRewards,
     TAccountMint,
     TAccountSystemProgram
-  >
+  >,
+  config?: { programAddress?: TProgramAddress }
 ): InitializeHolderRewardsInstruction<
-  typeof PALADIN_REWARDS_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountHolderRewardsPool,
-  TAccountHolderRewardsPoolTokenAccountInfo,
+  TAccountHolderRewardsPoolTokenAccount,
   TAccountOwner,
   TAccountHolderRewards,
   TAccountMint,
   TAccountSystemProgram
 > {
   // Program address.
-  const programAddress = PALADIN_REWARDS_PROGRAM_ADDRESS;
+  const programAddress =
+    config?.programAddress ?? PALADIN_REWARDS_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -151,8 +163,8 @@ export function getInitializeHolderRewardsInstruction<
       value: input.holderRewardsPool ?? null,
       isWritable: true,
     },
-    holderRewardsPoolTokenAccountInfo: {
-      value: input.holderRewardsPoolTokenAccountInfo ?? null,
+    holderRewardsPoolTokenAccount: {
+      value: input.holderRewardsPoolTokenAccount ?? null,
       isWritable: false,
     },
     owner: { value: input.owner ?? null, isWritable: true },
@@ -175,7 +187,7 @@ export function getInitializeHolderRewardsInstruction<
   const instruction = {
     accounts: [
       getAccountMeta(accounts.holderRewardsPool),
-      getAccountMeta(accounts.holderRewardsPoolTokenAccountInfo),
+      getAccountMeta(accounts.holderRewardsPoolTokenAccount),
       getAccountMeta(accounts.owner),
       getAccountMeta(accounts.holderRewards),
       getAccountMeta(accounts.mint),
@@ -184,9 +196,9 @@ export function getInitializeHolderRewardsInstruction<
     programAddress,
     data: getInitializeHolderRewardsInstructionDataEncoder().encode({}),
   } as InitializeHolderRewardsInstruction<
-    typeof PALADIN_REWARDS_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountHolderRewardsPool,
-    TAccountHolderRewardsPoolTokenAccountInfo,
+    TAccountHolderRewardsPoolTokenAccount,
     TAccountOwner,
     TAccountHolderRewards,
     TAccountMint,
@@ -205,7 +217,7 @@ export type ParsedInitializeHolderRewardsInstruction<
     /** Holder rewards pool account. */
     holderRewardsPool: TAccountMetas[0];
     /** Holder rewards pool token account. */
-    holderRewardsPoolTokenAccountInfo: TAccountMetas[1];
+    holderRewardsPoolTokenAccount: TAccountMetas[1];
     /** Token account owner. */
     owner: TAccountMetas[2];
     /** Holder rewards account. */
@@ -240,7 +252,7 @@ export function parseInitializeHolderRewardsInstruction<
     programAddress: instruction.programAddress,
     accounts: {
       holderRewardsPool: getNextAccount(),
-      holderRewardsPoolTokenAccountInfo: getNextAccount(),
+      holderRewardsPoolTokenAccount: getNextAccount(),
       owner: getNextAccount(),
       holderRewards: getNextAccount(),
       mint: getNextAccount(),

--- a/clients/js/src/generated/instructions/initializeHolderRewardsPool.ts
+++ b/clients/js/src/generated/instructions/initializeHolderRewardsPool.ts
@@ -27,10 +27,16 @@ import {
 import { PALADIN_REWARDS_PROGRAM_ADDRESS } from '../programs';
 import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
 
+export const INITIALIZE_HOLDER_REWARDS_POOL_DISCRIMINATOR = 0;
+
+export function getInitializeHolderRewardsPoolDiscriminatorBytes() {
+  return getU8Encoder().encode(INITIALIZE_HOLDER_REWARDS_POOL_DISCRIMINATOR);
+}
+
 export type InitializeHolderRewardsPoolInstruction<
   TProgram extends string = typeof PALADIN_REWARDS_PROGRAM_ADDRESS,
   TAccountHolderRewardsPool extends string | IAccountMeta<string> = string,
-  TAccountHolderRewardsPoolTokenAccountInfo extends
+  TAccountHolderRewardsPoolTokenAccount extends
     | string
     | IAccountMeta<string> = string,
   TAccountMint extends string | IAccountMeta<string> = string,
@@ -45,9 +51,9 @@ export type InitializeHolderRewardsPoolInstruction<
       TAccountHolderRewardsPool extends string
         ? WritableAccount<TAccountHolderRewardsPool>
         : TAccountHolderRewardsPool,
-      TAccountHolderRewardsPoolTokenAccountInfo extends string
-        ? ReadonlyAccount<TAccountHolderRewardsPoolTokenAccountInfo>
-        : TAccountHolderRewardsPoolTokenAccountInfo,
+      TAccountHolderRewardsPoolTokenAccount extends string
+        ? ReadonlyAccount<TAccountHolderRewardsPoolTokenAccount>
+        : TAccountHolderRewardsPoolTokenAccount,
       TAccountMint extends string
         ? ReadonlyAccount<TAccountMint>
         : TAccountMint,
@@ -67,7 +73,10 @@ export type InitializeHolderRewardsPoolInstructionDataArgs = {};
 export function getInitializeHolderRewardsPoolInstructionDataEncoder(): Encoder<InitializeHolderRewardsPoolInstructionDataArgs> {
   return transformEncoder(
     getStructEncoder([['discriminator', getU8Encoder()]]),
-    (value) => ({ ...value, discriminator: 0 })
+    (value) => ({
+      ...value,
+      discriminator: INITIALIZE_HOLDER_REWARDS_POOL_DISCRIMINATOR,
+    })
   );
 }
 
@@ -87,14 +96,14 @@ export function getInitializeHolderRewardsPoolInstructionDataCodec(): Codec<
 
 export type InitializeHolderRewardsPoolInput<
   TAccountHolderRewardsPool extends string = string,
-  TAccountHolderRewardsPoolTokenAccountInfo extends string = string,
+  TAccountHolderRewardsPoolTokenAccount extends string = string,
   TAccountMint extends string = string,
   TAccountSystemProgram extends string = string,
 > = {
   /** Holder rewards pool account. */
   holderRewardsPool: Address<TAccountHolderRewardsPool>;
   /** Holder rewards pool token account. */
-  holderRewardsPoolTokenAccountInfo: Address<TAccountHolderRewardsPoolTokenAccountInfo>;
+  holderRewardsPoolTokenAccount: Address<TAccountHolderRewardsPoolTokenAccount>;
   /** Token mint. */
   mint: Address<TAccountMint>;
   /** System program. */
@@ -103,25 +112,28 @@ export type InitializeHolderRewardsPoolInput<
 
 export function getInitializeHolderRewardsPoolInstruction<
   TAccountHolderRewardsPool extends string,
-  TAccountHolderRewardsPoolTokenAccountInfo extends string,
+  TAccountHolderRewardsPoolTokenAccount extends string,
   TAccountMint extends string,
   TAccountSystemProgram extends string,
+  TProgramAddress extends Address = typeof PALADIN_REWARDS_PROGRAM_ADDRESS,
 >(
   input: InitializeHolderRewardsPoolInput<
     TAccountHolderRewardsPool,
-    TAccountHolderRewardsPoolTokenAccountInfo,
+    TAccountHolderRewardsPoolTokenAccount,
     TAccountMint,
     TAccountSystemProgram
-  >
+  >,
+  config?: { programAddress?: TProgramAddress }
 ): InitializeHolderRewardsPoolInstruction<
-  typeof PALADIN_REWARDS_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountHolderRewardsPool,
-  TAccountHolderRewardsPoolTokenAccountInfo,
+  TAccountHolderRewardsPoolTokenAccount,
   TAccountMint,
   TAccountSystemProgram
 > {
   // Program address.
-  const programAddress = PALADIN_REWARDS_PROGRAM_ADDRESS;
+  const programAddress =
+    config?.programAddress ?? PALADIN_REWARDS_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -129,8 +141,8 @@ export function getInitializeHolderRewardsPoolInstruction<
       value: input.holderRewardsPool ?? null,
       isWritable: true,
     },
-    holderRewardsPoolTokenAccountInfo: {
-      value: input.holderRewardsPoolTokenAccountInfo ?? null,
+    holderRewardsPoolTokenAccount: {
+      value: input.holderRewardsPoolTokenAccount ?? null,
       isWritable: false,
     },
     mint: { value: input.mint ?? null, isWritable: false },
@@ -151,16 +163,16 @@ export function getInitializeHolderRewardsPoolInstruction<
   const instruction = {
     accounts: [
       getAccountMeta(accounts.holderRewardsPool),
-      getAccountMeta(accounts.holderRewardsPoolTokenAccountInfo),
+      getAccountMeta(accounts.holderRewardsPoolTokenAccount),
       getAccountMeta(accounts.mint),
       getAccountMeta(accounts.systemProgram),
     ],
     programAddress,
     data: getInitializeHolderRewardsPoolInstructionDataEncoder().encode({}),
   } as InitializeHolderRewardsPoolInstruction<
-    typeof PALADIN_REWARDS_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountHolderRewardsPool,
-    TAccountHolderRewardsPoolTokenAccountInfo,
+    TAccountHolderRewardsPoolTokenAccount,
     TAccountMint,
     TAccountSystemProgram
   >;
@@ -177,7 +189,7 @@ export type ParsedInitializeHolderRewardsPoolInstruction<
     /** Holder rewards pool account. */
     holderRewardsPool: TAccountMetas[0];
     /** Holder rewards pool token account. */
-    holderRewardsPoolTokenAccountInfo: TAccountMetas[1];
+    holderRewardsPoolTokenAccount: TAccountMetas[1];
     /** Token mint. */
     mint: TAccountMetas[2];
     /** System program. */
@@ -208,7 +220,7 @@ export function parseInitializeHolderRewardsPoolInstruction<
     programAddress: instruction.programAddress,
     accounts: {
       holderRewardsPool: getNextAccount(),
-      holderRewardsPoolTokenAccountInfo: getNextAccount(),
+      holderRewardsPoolTokenAccount: getNextAccount(),
       mint: getNextAccount(),
       systemProgram: getNextAccount(),
     },

--- a/clients/js/src/generated/pdas/holderRewards.ts
+++ b/clients/js/src/generated/pdas/holderRewards.ts
@@ -15,8 +15,8 @@ import {
 } from '@solana/web3.js';
 
 export type HolderRewardsSeeds = {
-  /** Token account */
-  tokenAccount: Address;
+  /** Owner */
+  owner: Address;
 };
 
 export async function findHolderRewardsPda(
@@ -30,7 +30,7 @@ export async function findHolderRewardsPda(
     programAddress,
     seeds: [
       getUtf8Encoder().encode('holder'),
-      getAddressEncoder().encode(seeds.tokenAccount),
+      getAddressEncoder().encode(seeds.owner),
     ],
   });
 }

--- a/clients/rust/src/generated/accounts/holder_rewards.rs
+++ b/clients/rust/src/generated/accounts/holder_rewards.rs
@@ -25,22 +25,22 @@ impl HolderRewards {
     /// Values are positional and appear in the following order:
     ///
     ///   0. `HolderRewards::PREFIX`
-    ///   1. token_account (`Pubkey`)
+    ///   1. owner (`Pubkey`)
     pub const PREFIX: &'static [u8] = "holder".as_bytes();
 
     pub fn create_pda(
-        token_account: Pubkey,
+        owner: Pubkey,
         bump: u8,
     ) -> Result<solana_program::pubkey::Pubkey, solana_program::pubkey::PubkeyError> {
         solana_program::pubkey::Pubkey::create_program_address(
-            &["holder".as_bytes(), token_account.as_ref(), &[bump]],
+            &["holder".as_bytes(), owner.as_ref(), &[bump]],
             &crate::PALADIN_REWARDS_ID,
         )
     }
 
-    pub fn find_pda(token_account: &Pubkey) -> (solana_program::pubkey::Pubkey, u8) {
+    pub fn find_pda(owner: &Pubkey) -> (solana_program::pubkey::Pubkey, u8) {
         solana_program::pubkey::Pubkey::find_program_address(
-            &["holder".as_bytes(), token_account.as_ref()],
+            &["holder".as_bytes(), owner.as_ref()],
             &crate::PALADIN_REWARDS_ID,
         )
     }

--- a/clients/rust/src/generated/errors/paladin_rewards.rs
+++ b/clients/rust/src/generated/errors/paladin_rewards.rs
@@ -50,6 +50,9 @@ pub enum PaladinRewardsError {
     /// 13 - Owner doesn'thave enough tokens to deposit
     #[error("Owner doesn'thave enough tokens to deposit")]
     NotEnoughTokenToDeposit = 0xD,
+    /// 14 - Withdraw amount exceeds deposited
+    #[error("Withdraw amount exceeds deposited")]
+    WithdrawExceedsDeposited = 0xE,
 }
 
 impl solana_program::program_error::PrintProgramError for PaladinRewardsError {

--- a/clients/rust/src/generated/instructions/close_holder_rewards.rs
+++ b/clients/rust/src/generated/instructions/close_holder_rewards.rs
@@ -11,11 +11,9 @@ pub struct CloseHolderRewards {
     /// Holder rewards pool account.
     pub holder_rewards_pool: solana_program::pubkey::Pubkey,
     /// Holder rewards pool token account.
-    pub holder_rewards_pool_token_account_info: solana_program::pubkey::Pubkey,
+    pub holder_rewards_pool_token_account: solana_program::pubkey::Pubkey,
     /// Holder rewards account.
     pub holder_rewards: solana_program::pubkey::Pubkey,
-    /// Token account.
-    pub token_account: solana_program::pubkey::Pubkey,
     /// Token mint.
     pub mint: solana_program::pubkey::Pubkey,
     /// Owner of the account.
@@ -31,21 +29,17 @@ impl CloseHolderRewards {
         &self,
         remaining_accounts: &[solana_program::instruction::AccountMeta],
     ) -> solana_program::instruction::Instruction {
-        let mut accounts = Vec::with_capacity(6 + remaining_accounts.len());
+        let mut accounts = Vec::with_capacity(5 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
             self.holder_rewards_pool,
             false,
         ));
         accounts.push(solana_program::instruction::AccountMeta::new(
-            self.holder_rewards_pool_token_account_info,
+            self.holder_rewards_pool_token_account,
             false,
         ));
         accounts.push(solana_program::instruction::AccountMeta::new(
             self.holder_rewards,
-            false,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
-            self.token_account,
             false,
         ));
         accounts.push(solana_program::instruction::AccountMeta::new_readonly(
@@ -89,17 +83,15 @@ impl Default for CloseHolderRewardsInstructionData {
 /// ### Accounts:
 ///
 ///   0. `[writable]` holder_rewards_pool
-///   1. `[writable]` holder_rewards_pool_token_account_info
+///   1. `[writable]` holder_rewards_pool_token_account
 ///   2. `[writable]` holder_rewards
-///   3. `[]` token_account
-///   4. `[]` mint
-///   5. `[writable, signer]` owner
+///   3. `[]` mint
+///   4. `[writable, signer]` owner
 #[derive(Clone, Debug, Default)]
 pub struct CloseHolderRewardsBuilder {
     holder_rewards_pool: Option<solana_program::pubkey::Pubkey>,
-    holder_rewards_pool_token_account_info: Option<solana_program::pubkey::Pubkey>,
+    holder_rewards_pool_token_account: Option<solana_program::pubkey::Pubkey>,
     holder_rewards: Option<solana_program::pubkey::Pubkey>,
-    token_account: Option<solana_program::pubkey::Pubkey>,
     mint: Option<solana_program::pubkey::Pubkey>,
     owner: Option<solana_program::pubkey::Pubkey>,
     __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
@@ -120,23 +112,17 @@ impl CloseHolderRewardsBuilder {
     }
     /// Holder rewards pool token account.
     #[inline(always)]
-    pub fn holder_rewards_pool_token_account_info(
+    pub fn holder_rewards_pool_token_account(
         &mut self,
-        holder_rewards_pool_token_account_info: solana_program::pubkey::Pubkey,
+        holder_rewards_pool_token_account: solana_program::pubkey::Pubkey,
     ) -> &mut Self {
-        self.holder_rewards_pool_token_account_info = Some(holder_rewards_pool_token_account_info);
+        self.holder_rewards_pool_token_account = Some(holder_rewards_pool_token_account);
         self
     }
     /// Holder rewards account.
     #[inline(always)]
     pub fn holder_rewards(&mut self, holder_rewards: solana_program::pubkey::Pubkey) -> &mut Self {
         self.holder_rewards = Some(holder_rewards);
-        self
-    }
-    /// Token account.
-    #[inline(always)]
-    pub fn token_account(&mut self, token_account: solana_program::pubkey::Pubkey) -> &mut Self {
-        self.token_account = Some(token_account);
         self
     }
     /// Token mint.
@@ -151,7 +137,7 @@ impl CloseHolderRewardsBuilder {
         self.owner = Some(owner);
         self
     }
-    /// Add an aditional account to the instruction.
+    /// Add an additional account to the instruction.
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
@@ -175,11 +161,10 @@ impl CloseHolderRewardsBuilder {
             holder_rewards_pool: self
                 .holder_rewards_pool
                 .expect("holder_rewards_pool is not set"),
-            holder_rewards_pool_token_account_info: self
-                .holder_rewards_pool_token_account_info
-                .expect("holder_rewards_pool_token_account_info is not set"),
+            holder_rewards_pool_token_account: self
+                .holder_rewards_pool_token_account
+                .expect("holder_rewards_pool_token_account is not set"),
             holder_rewards: self.holder_rewards.expect("holder_rewards is not set"),
-            token_account: self.token_account.expect("token_account is not set"),
             mint: self.mint.expect("mint is not set"),
             owner: self.owner.expect("owner is not set"),
         };
@@ -193,11 +178,9 @@ pub struct CloseHolderRewardsCpiAccounts<'a, 'b> {
     /// Holder rewards pool account.
     pub holder_rewards_pool: &'b solana_program::account_info::AccountInfo<'a>,
     /// Holder rewards pool token account.
-    pub holder_rewards_pool_token_account_info: &'b solana_program::account_info::AccountInfo<'a>,
+    pub holder_rewards_pool_token_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// Holder rewards account.
     pub holder_rewards: &'b solana_program::account_info::AccountInfo<'a>,
-    /// Token account.
-    pub token_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token mint.
     pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Owner of the account.
@@ -211,11 +194,9 @@ pub struct CloseHolderRewardsCpi<'a, 'b> {
     /// Holder rewards pool account.
     pub holder_rewards_pool: &'b solana_program::account_info::AccountInfo<'a>,
     /// Holder rewards pool token account.
-    pub holder_rewards_pool_token_account_info: &'b solana_program::account_info::AccountInfo<'a>,
+    pub holder_rewards_pool_token_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// Holder rewards account.
     pub holder_rewards: &'b solana_program::account_info::AccountInfo<'a>,
-    /// Token account.
-    pub token_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token mint.
     pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Owner of the account.
@@ -230,9 +211,8 @@ impl<'a, 'b> CloseHolderRewardsCpi<'a, 'b> {
         Self {
             __program: program,
             holder_rewards_pool: accounts.holder_rewards_pool,
-            holder_rewards_pool_token_account_info: accounts.holder_rewards_pool_token_account_info,
+            holder_rewards_pool_token_account: accounts.holder_rewards_pool_token_account,
             holder_rewards: accounts.holder_rewards,
-            token_account: accounts.token_account,
             mint: accounts.mint,
             owner: accounts.owner,
         }
@@ -270,21 +250,17 @@ impl<'a, 'b> CloseHolderRewardsCpi<'a, 'b> {
             bool,
         )],
     ) -> solana_program::entrypoint::ProgramResult {
-        let mut accounts = Vec::with_capacity(6 + remaining_accounts.len());
+        let mut accounts = Vec::with_capacity(5 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
             *self.holder_rewards_pool.key,
             false,
         ));
         accounts.push(solana_program::instruction::AccountMeta::new(
-            *self.holder_rewards_pool_token_account_info.key,
+            *self.holder_rewards_pool_token_account.key,
             false,
         ));
         accounts.push(solana_program::instruction::AccountMeta::new(
             *self.holder_rewards.key,
-            false,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
-            *self.token_account.key,
             false,
         ));
         accounts.push(solana_program::instruction::AccountMeta::new_readonly(
@@ -311,12 +287,11 @@ impl<'a, 'b> CloseHolderRewardsCpi<'a, 'b> {
             accounts,
             data,
         };
-        let mut account_infos = Vec::with_capacity(6 + 1 + remaining_accounts.len());
+        let mut account_infos = Vec::with_capacity(5 + 1 + remaining_accounts.len());
         account_infos.push(self.__program.clone());
         account_infos.push(self.holder_rewards_pool.clone());
-        account_infos.push(self.holder_rewards_pool_token_account_info.clone());
+        account_infos.push(self.holder_rewards_pool_token_account.clone());
         account_infos.push(self.holder_rewards.clone());
-        account_infos.push(self.token_account.clone());
         account_infos.push(self.mint.clone());
         account_infos.push(self.owner.clone());
         remaining_accounts
@@ -336,11 +311,10 @@ impl<'a, 'b> CloseHolderRewardsCpi<'a, 'b> {
 /// ### Accounts:
 ///
 ///   0. `[writable]` holder_rewards_pool
-///   1. `[writable]` holder_rewards_pool_token_account_info
+///   1. `[writable]` holder_rewards_pool_token_account
 ///   2. `[writable]` holder_rewards
-///   3. `[]` token_account
-///   4. `[]` mint
-///   5. `[writable, signer]` owner
+///   3. `[]` mint
+///   4. `[writable, signer]` owner
 #[derive(Clone, Debug)]
 pub struct CloseHolderRewardsCpiBuilder<'a, 'b> {
     instruction: Box<CloseHolderRewardsCpiBuilderInstruction<'a, 'b>>,
@@ -351,9 +325,8 @@ impl<'a, 'b> CloseHolderRewardsCpiBuilder<'a, 'b> {
         let instruction = Box::new(CloseHolderRewardsCpiBuilderInstruction {
             __program: program,
             holder_rewards_pool: None,
-            holder_rewards_pool_token_account_info: None,
+            holder_rewards_pool_token_account: None,
             holder_rewards: None,
-            token_account: None,
             mint: None,
             owner: None,
             __remaining_accounts: Vec::new(),
@@ -371,12 +344,12 @@ impl<'a, 'b> CloseHolderRewardsCpiBuilder<'a, 'b> {
     }
     /// Holder rewards pool token account.
     #[inline(always)]
-    pub fn holder_rewards_pool_token_account_info(
+    pub fn holder_rewards_pool_token_account(
         &mut self,
-        holder_rewards_pool_token_account_info: &'b solana_program::account_info::AccountInfo<'a>,
+        holder_rewards_pool_token_account: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
-        self.instruction.holder_rewards_pool_token_account_info =
-            Some(holder_rewards_pool_token_account_info);
+        self.instruction.holder_rewards_pool_token_account =
+            Some(holder_rewards_pool_token_account);
         self
     }
     /// Holder rewards account.
@@ -386,15 +359,6 @@ impl<'a, 'b> CloseHolderRewardsCpiBuilder<'a, 'b> {
         holder_rewards: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.holder_rewards = Some(holder_rewards);
-        self
-    }
-    /// Token account.
-    #[inline(always)]
-    pub fn token_account(
-        &mut self,
-        token_account: &'b solana_program::account_info::AccountInfo<'a>,
-    ) -> &mut Self {
-        self.instruction.token_account = Some(token_account);
         self
     }
     /// Token mint.
@@ -459,20 +423,15 @@ impl<'a, 'b> CloseHolderRewardsCpiBuilder<'a, 'b> {
                 .holder_rewards_pool
                 .expect("holder_rewards_pool is not set"),
 
-            holder_rewards_pool_token_account_info: self
+            holder_rewards_pool_token_account: self
                 .instruction
-                .holder_rewards_pool_token_account_info
-                .expect("holder_rewards_pool_token_account_info is not set"),
+                .holder_rewards_pool_token_account
+                .expect("holder_rewards_pool_token_account is not set"),
 
             holder_rewards: self
                 .instruction
                 .holder_rewards
                 .expect("holder_rewards is not set"),
-
-            token_account: self
-                .instruction
-                .token_account
-                .expect("token_account is not set"),
 
             mint: self.instruction.mint.expect("mint is not set"),
 
@@ -489,10 +448,8 @@ impl<'a, 'b> CloseHolderRewardsCpiBuilder<'a, 'b> {
 struct CloseHolderRewardsCpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_program::account_info::AccountInfo<'a>,
     holder_rewards_pool: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    holder_rewards_pool_token_account_info:
-        Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    holder_rewards_pool_token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     holder_rewards: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     owner: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.

--- a/clients/rust/src/generated/instructions/deposit.rs
+++ b/clients/rust/src/generated/instructions/deposit.rs
@@ -42,7 +42,7 @@ impl Deposit {
             self.holder_rewards_pool,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_program::instruction::AccountMeta::new(
             self.holder_rewards_pool_token_account,
             false,
         ));
@@ -105,7 +105,7 @@ pub struct DepositInstructionArgs {
 /// ### Accounts:
 ///
 ///   0. `[writable]` holder_rewards_pool
-///   1. `[]` holder_rewards_pool_token_account
+///   1. `[writable]` holder_rewards_pool_token_account
 ///   2. `[writable]` holder_rewards
 ///   3. `[writable]` token_account
 ///   4. `[]` mint
@@ -322,7 +322,7 @@ impl<'a, 'b> DepositCpi<'a, 'b> {
             *self.holder_rewards_pool.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_program::instruction::AccountMeta::new(
             *self.holder_rewards_pool_token_account.key,
             false,
         ));
@@ -388,7 +388,7 @@ impl<'a, 'b> DepositCpi<'a, 'b> {
 /// ### Accounts:
 ///
 ///   0. `[writable]` holder_rewards_pool
-///   1. `[]` holder_rewards_pool_token_account
+///   1. `[writable]` holder_rewards_pool_token_account
 ///   2. `[writable]` holder_rewards
 ///   3. `[writable]` token_account
 ///   4. `[]` mint

--- a/clients/rust/src/generated/instructions/deposit.rs
+++ b/clients/rust/src/generated/instructions/deposit.rs
@@ -57,7 +57,7 @@ impl Deposit {
         accounts.push(solana_program::instruction::AccountMeta::new_readonly(
             self.mint, false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_program::instruction::AccountMeta::new(
             self.owner, true,
         ));
         accounts.push(solana_program::instruction::AccountMeta::new_readonly(
@@ -109,7 +109,7 @@ pub struct DepositInstructionArgs {
 ///   2. `[writable]` holder_rewards
 ///   3. `[writable]` token_account
 ///   4. `[]` mint
-///   5. `[signer]` owner
+///   5. `[writable, signer]` owner
 ///   6. `[optional]` token_program (default to
 ///      `TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA`)
 #[derive(Clone, Debug, Default)]
@@ -183,7 +183,7 @@ impl DepositBuilder {
         self.amount = Some(amount);
         self
     }
-    /// Add an aditional account to the instruction.
+    /// Add an additional account to the instruction.
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
@@ -338,7 +338,7 @@ impl<'a, 'b> DepositCpi<'a, 'b> {
             *self.mint.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_program::instruction::AccountMeta::new(
             *self.owner.key,
             true,
         ));
@@ -392,7 +392,7 @@ impl<'a, 'b> DepositCpi<'a, 'b> {
 ///   2. `[writable]` holder_rewards
 ///   3. `[writable]` token_account
 ///   4. `[]` mint
-///   5. `[signer]` owner
+///   5. `[writable, signer]` owner
 ///   6. `[]` token_program
 #[derive(Clone, Debug)]
 pub struct DepositCpiBuilder<'a, 'b> {

--- a/clients/rust/src/generated/instructions/harvest_rewards.rs
+++ b/clients/rust/src/generated/instructions/harvest_rewards.rs
@@ -11,7 +11,7 @@ pub struct HarvestRewards {
     /// Holder rewards pool account.
     pub holder_rewards_pool: solana_program::pubkey::Pubkey,
     /// Holder rewards pool token account.
-    pub holder_rewards_pool_token_account_info: solana_program::pubkey::Pubkey,
+    pub holder_rewards_pool_token_account: solana_program::pubkey::Pubkey,
     /// Holder rewards account.
     pub holder_rewards: solana_program::pubkey::Pubkey,
     /// Token mint.
@@ -35,7 +35,7 @@ impl HarvestRewards {
             false,
         ));
         accounts.push(solana_program::instruction::AccountMeta::new_readonly(
-            self.holder_rewards_pool_token_account_info,
+            self.holder_rewards_pool_token_account,
             false,
         ));
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -81,14 +81,14 @@ impl Default for HarvestRewardsInstructionData {
 /// ### Accounts:
 ///
 ///   0. `[writable]` holder_rewards_pool
-///   1. `[]` holder_rewards_pool_token_account_info
+///   1. `[]` holder_rewards_pool_token_account
 ///   2. `[writable]` holder_rewards
 ///   3. `[]` mint
 ///   4. `[writable, signer]` owner
 #[derive(Clone, Debug, Default)]
 pub struct HarvestRewardsBuilder {
     holder_rewards_pool: Option<solana_program::pubkey::Pubkey>,
-    holder_rewards_pool_token_account_info: Option<solana_program::pubkey::Pubkey>,
+    holder_rewards_pool_token_account: Option<solana_program::pubkey::Pubkey>,
     holder_rewards: Option<solana_program::pubkey::Pubkey>,
     mint: Option<solana_program::pubkey::Pubkey>,
     owner: Option<solana_program::pubkey::Pubkey>,
@@ -110,11 +110,11 @@ impl HarvestRewardsBuilder {
     }
     /// Holder rewards pool token account.
     #[inline(always)]
-    pub fn holder_rewards_pool_token_account_info(
+    pub fn holder_rewards_pool_token_account(
         &mut self,
-        holder_rewards_pool_token_account_info: solana_program::pubkey::Pubkey,
+        holder_rewards_pool_token_account: solana_program::pubkey::Pubkey,
     ) -> &mut Self {
-        self.holder_rewards_pool_token_account_info = Some(holder_rewards_pool_token_account_info);
+        self.holder_rewards_pool_token_account = Some(holder_rewards_pool_token_account);
         self
     }
     /// Holder rewards account.
@@ -135,7 +135,7 @@ impl HarvestRewardsBuilder {
         self.owner = Some(owner);
         self
     }
-    /// Add an aditional account to the instruction.
+    /// Add an additional account to the instruction.
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
@@ -159,9 +159,9 @@ impl HarvestRewardsBuilder {
             holder_rewards_pool: self
                 .holder_rewards_pool
                 .expect("holder_rewards_pool is not set"),
-            holder_rewards_pool_token_account_info: self
-                .holder_rewards_pool_token_account_info
-                .expect("holder_rewards_pool_token_account_info is not set"),
+            holder_rewards_pool_token_account: self
+                .holder_rewards_pool_token_account
+                .expect("holder_rewards_pool_token_account is not set"),
             holder_rewards: self.holder_rewards.expect("holder_rewards is not set"),
             mint: self.mint.expect("mint is not set"),
             owner: self.owner.expect("owner is not set"),
@@ -176,7 +176,7 @@ pub struct HarvestRewardsCpiAccounts<'a, 'b> {
     /// Holder rewards pool account.
     pub holder_rewards_pool: &'b solana_program::account_info::AccountInfo<'a>,
     /// Holder rewards pool token account.
-    pub holder_rewards_pool_token_account_info: &'b solana_program::account_info::AccountInfo<'a>,
+    pub holder_rewards_pool_token_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// Holder rewards account.
     pub holder_rewards: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token mint.
@@ -192,7 +192,7 @@ pub struct HarvestRewardsCpi<'a, 'b> {
     /// Holder rewards pool account.
     pub holder_rewards_pool: &'b solana_program::account_info::AccountInfo<'a>,
     /// Holder rewards pool token account.
-    pub holder_rewards_pool_token_account_info: &'b solana_program::account_info::AccountInfo<'a>,
+    pub holder_rewards_pool_token_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// Holder rewards account.
     pub holder_rewards: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token mint.
@@ -209,7 +209,7 @@ impl<'a, 'b> HarvestRewardsCpi<'a, 'b> {
         Self {
             __program: program,
             holder_rewards_pool: accounts.holder_rewards_pool,
-            holder_rewards_pool_token_account_info: accounts.holder_rewards_pool_token_account_info,
+            holder_rewards_pool_token_account: accounts.holder_rewards_pool_token_account,
             holder_rewards: accounts.holder_rewards,
             mint: accounts.mint,
             owner: accounts.owner,
@@ -254,7 +254,7 @@ impl<'a, 'b> HarvestRewardsCpi<'a, 'b> {
             false,
         ));
         accounts.push(solana_program::instruction::AccountMeta::new_readonly(
-            *self.holder_rewards_pool_token_account_info.key,
+            *self.holder_rewards_pool_token_account.key,
             false,
         ));
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -286,7 +286,7 @@ impl<'a, 'b> HarvestRewardsCpi<'a, 'b> {
         let mut account_infos = Vec::with_capacity(5 + 1 + remaining_accounts.len());
         account_infos.push(self.__program.clone());
         account_infos.push(self.holder_rewards_pool.clone());
-        account_infos.push(self.holder_rewards_pool_token_account_info.clone());
+        account_infos.push(self.holder_rewards_pool_token_account.clone());
         account_infos.push(self.holder_rewards.clone());
         account_infos.push(self.mint.clone());
         account_infos.push(self.owner.clone());
@@ -307,7 +307,7 @@ impl<'a, 'b> HarvestRewardsCpi<'a, 'b> {
 /// ### Accounts:
 ///
 ///   0. `[writable]` holder_rewards_pool
-///   1. `[]` holder_rewards_pool_token_account_info
+///   1. `[]` holder_rewards_pool_token_account
 ///   2. `[writable]` holder_rewards
 ///   3. `[]` mint
 ///   4. `[writable, signer]` owner
@@ -321,7 +321,7 @@ impl<'a, 'b> HarvestRewardsCpiBuilder<'a, 'b> {
         let instruction = Box::new(HarvestRewardsCpiBuilderInstruction {
             __program: program,
             holder_rewards_pool: None,
-            holder_rewards_pool_token_account_info: None,
+            holder_rewards_pool_token_account: None,
             holder_rewards: None,
             mint: None,
             owner: None,
@@ -340,12 +340,12 @@ impl<'a, 'b> HarvestRewardsCpiBuilder<'a, 'b> {
     }
     /// Holder rewards pool token account.
     #[inline(always)]
-    pub fn holder_rewards_pool_token_account_info(
+    pub fn holder_rewards_pool_token_account(
         &mut self,
-        holder_rewards_pool_token_account_info: &'b solana_program::account_info::AccountInfo<'a>,
+        holder_rewards_pool_token_account: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
-        self.instruction.holder_rewards_pool_token_account_info =
-            Some(holder_rewards_pool_token_account_info);
+        self.instruction.holder_rewards_pool_token_account =
+            Some(holder_rewards_pool_token_account);
         self
     }
     /// Holder rewards account.
@@ -419,10 +419,10 @@ impl<'a, 'b> HarvestRewardsCpiBuilder<'a, 'b> {
                 .holder_rewards_pool
                 .expect("holder_rewards_pool is not set"),
 
-            holder_rewards_pool_token_account_info: self
+            holder_rewards_pool_token_account: self
                 .instruction
-                .holder_rewards_pool_token_account_info
-                .expect("holder_rewards_pool_token_account_info is not set"),
+                .holder_rewards_pool_token_account
+                .expect("holder_rewards_pool_token_account is not set"),
 
             holder_rewards: self
                 .instruction
@@ -444,8 +444,7 @@ impl<'a, 'b> HarvestRewardsCpiBuilder<'a, 'b> {
 struct HarvestRewardsCpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_program::account_info::AccountInfo<'a>,
     holder_rewards_pool: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    holder_rewards_pool_token_account_info:
-        Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    holder_rewards_pool_token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     holder_rewards: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     owner: Option<&'b solana_program::account_info::AccountInfo<'a>>,

--- a/clients/rust/src/generated/instructions/initialize_holder_rewards.rs
+++ b/clients/rust/src/generated/instructions/initialize_holder_rewards.rs
@@ -11,7 +11,7 @@ pub struct InitializeHolderRewards {
     /// Holder rewards pool account.
     pub holder_rewards_pool: solana_program::pubkey::Pubkey,
     /// Holder rewards pool token account.
-    pub holder_rewards_pool_token_account_info: solana_program::pubkey::Pubkey,
+    pub holder_rewards_pool_token_account: solana_program::pubkey::Pubkey,
     /// Token account owner.
     pub owner: solana_program::pubkey::Pubkey,
     /// Holder rewards account.
@@ -37,7 +37,7 @@ impl InitializeHolderRewards {
             false,
         ));
         accounts.push(solana_program::instruction::AccountMeta::new_readonly(
-            self.holder_rewards_pool_token_account_info,
+            self.holder_rewards_pool_token_account,
             false,
         ));
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -89,7 +89,7 @@ impl Default for InitializeHolderRewardsInstructionData {
 /// ### Accounts:
 ///
 ///   0. `[writable]` holder_rewards_pool
-///   1. `[]` holder_rewards_pool_token_account_info
+///   1. `[]` holder_rewards_pool_token_account
 ///   2. `[writable, signer]` owner
 ///   3. `[writable]` holder_rewards
 ///   4. `[]` mint
@@ -98,7 +98,7 @@ impl Default for InitializeHolderRewardsInstructionData {
 #[derive(Clone, Debug, Default)]
 pub struct InitializeHolderRewardsBuilder {
     holder_rewards_pool: Option<solana_program::pubkey::Pubkey>,
-    holder_rewards_pool_token_account_info: Option<solana_program::pubkey::Pubkey>,
+    holder_rewards_pool_token_account: Option<solana_program::pubkey::Pubkey>,
     owner: Option<solana_program::pubkey::Pubkey>,
     holder_rewards: Option<solana_program::pubkey::Pubkey>,
     mint: Option<solana_program::pubkey::Pubkey>,
@@ -121,11 +121,11 @@ impl InitializeHolderRewardsBuilder {
     }
     /// Holder rewards pool token account.
     #[inline(always)]
-    pub fn holder_rewards_pool_token_account_info(
+    pub fn holder_rewards_pool_token_account(
         &mut self,
-        holder_rewards_pool_token_account_info: solana_program::pubkey::Pubkey,
+        holder_rewards_pool_token_account: solana_program::pubkey::Pubkey,
     ) -> &mut Self {
-        self.holder_rewards_pool_token_account_info = Some(holder_rewards_pool_token_account_info);
+        self.holder_rewards_pool_token_account = Some(holder_rewards_pool_token_account);
         self
     }
     /// Token account owner.
@@ -153,7 +153,7 @@ impl InitializeHolderRewardsBuilder {
         self.system_program = Some(system_program);
         self
     }
-    /// Add an aditional account to the instruction.
+    /// Add an additional account to the instruction.
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
@@ -177,9 +177,9 @@ impl InitializeHolderRewardsBuilder {
             holder_rewards_pool: self
                 .holder_rewards_pool
                 .expect("holder_rewards_pool is not set"),
-            holder_rewards_pool_token_account_info: self
-                .holder_rewards_pool_token_account_info
-                .expect("holder_rewards_pool_token_account_info is not set"),
+            holder_rewards_pool_token_account: self
+                .holder_rewards_pool_token_account
+                .expect("holder_rewards_pool_token_account is not set"),
             owner: self.owner.expect("owner is not set"),
             holder_rewards: self.holder_rewards.expect("holder_rewards is not set"),
             mint: self.mint.expect("mint is not set"),
@@ -197,7 +197,7 @@ pub struct InitializeHolderRewardsCpiAccounts<'a, 'b> {
     /// Holder rewards pool account.
     pub holder_rewards_pool: &'b solana_program::account_info::AccountInfo<'a>,
     /// Holder rewards pool token account.
-    pub holder_rewards_pool_token_account_info: &'b solana_program::account_info::AccountInfo<'a>,
+    pub holder_rewards_pool_token_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account owner.
     pub owner: &'b solana_program::account_info::AccountInfo<'a>,
     /// Holder rewards account.
@@ -215,7 +215,7 @@ pub struct InitializeHolderRewardsCpi<'a, 'b> {
     /// Holder rewards pool account.
     pub holder_rewards_pool: &'b solana_program::account_info::AccountInfo<'a>,
     /// Holder rewards pool token account.
-    pub holder_rewards_pool_token_account_info: &'b solana_program::account_info::AccountInfo<'a>,
+    pub holder_rewards_pool_token_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account owner.
     pub owner: &'b solana_program::account_info::AccountInfo<'a>,
     /// Holder rewards account.
@@ -234,7 +234,7 @@ impl<'a, 'b> InitializeHolderRewardsCpi<'a, 'b> {
         Self {
             __program: program,
             holder_rewards_pool: accounts.holder_rewards_pool,
-            holder_rewards_pool_token_account_info: accounts.holder_rewards_pool_token_account_info,
+            holder_rewards_pool_token_account: accounts.holder_rewards_pool_token_account,
             owner: accounts.owner,
             holder_rewards: accounts.holder_rewards,
             mint: accounts.mint,
@@ -280,7 +280,7 @@ impl<'a, 'b> InitializeHolderRewardsCpi<'a, 'b> {
             false,
         ));
         accounts.push(solana_program::instruction::AccountMeta::new_readonly(
-            *self.holder_rewards_pool_token_account_info.key,
+            *self.holder_rewards_pool_token_account.key,
             false,
         ));
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -318,7 +318,7 @@ impl<'a, 'b> InitializeHolderRewardsCpi<'a, 'b> {
         let mut account_infos = Vec::with_capacity(6 + 1 + remaining_accounts.len());
         account_infos.push(self.__program.clone());
         account_infos.push(self.holder_rewards_pool.clone());
-        account_infos.push(self.holder_rewards_pool_token_account_info.clone());
+        account_infos.push(self.holder_rewards_pool_token_account.clone());
         account_infos.push(self.owner.clone());
         account_infos.push(self.holder_rewards.clone());
         account_infos.push(self.mint.clone());
@@ -340,7 +340,7 @@ impl<'a, 'b> InitializeHolderRewardsCpi<'a, 'b> {
 /// ### Accounts:
 ///
 ///   0. `[writable]` holder_rewards_pool
-///   1. `[]` holder_rewards_pool_token_account_info
+///   1. `[]` holder_rewards_pool_token_account
 ///   2. `[writable, signer]` owner
 ///   3. `[writable]` holder_rewards
 ///   4. `[]` mint
@@ -355,7 +355,7 @@ impl<'a, 'b> InitializeHolderRewardsCpiBuilder<'a, 'b> {
         let instruction = Box::new(InitializeHolderRewardsCpiBuilderInstruction {
             __program: program,
             holder_rewards_pool: None,
-            holder_rewards_pool_token_account_info: None,
+            holder_rewards_pool_token_account: None,
             owner: None,
             holder_rewards: None,
             mint: None,
@@ -375,12 +375,12 @@ impl<'a, 'b> InitializeHolderRewardsCpiBuilder<'a, 'b> {
     }
     /// Holder rewards pool token account.
     #[inline(always)]
-    pub fn holder_rewards_pool_token_account_info(
+    pub fn holder_rewards_pool_token_account(
         &mut self,
-        holder_rewards_pool_token_account_info: &'b solana_program::account_info::AccountInfo<'a>,
+        holder_rewards_pool_token_account: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
-        self.instruction.holder_rewards_pool_token_account_info =
-            Some(holder_rewards_pool_token_account_info);
+        self.instruction.holder_rewards_pool_token_account =
+            Some(holder_rewards_pool_token_account);
         self
     }
     /// Token account owner.
@@ -463,10 +463,10 @@ impl<'a, 'b> InitializeHolderRewardsCpiBuilder<'a, 'b> {
                 .holder_rewards_pool
                 .expect("holder_rewards_pool is not set"),
 
-            holder_rewards_pool_token_account_info: self
+            holder_rewards_pool_token_account: self
                 .instruction
-                .holder_rewards_pool_token_account_info
-                .expect("holder_rewards_pool_token_account_info is not set"),
+                .holder_rewards_pool_token_account
+                .expect("holder_rewards_pool_token_account is not set"),
 
             owner: self.instruction.owner.expect("owner is not set"),
 
@@ -493,8 +493,7 @@ impl<'a, 'b> InitializeHolderRewardsCpiBuilder<'a, 'b> {
 struct InitializeHolderRewardsCpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_program::account_info::AccountInfo<'a>,
     holder_rewards_pool: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    holder_rewards_pool_token_account_info:
-        Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    holder_rewards_pool_token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     owner: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     holder_rewards: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,

--- a/clients/rust/src/generated/instructions/initialize_holder_rewards_pool.rs
+++ b/clients/rust/src/generated/instructions/initialize_holder_rewards_pool.rs
@@ -11,7 +11,7 @@ pub struct InitializeHolderRewardsPool {
     /// Holder rewards pool account.
     pub holder_rewards_pool: solana_program::pubkey::Pubkey,
     /// Holder rewards pool token account.
-    pub holder_rewards_pool_token_account_info: solana_program::pubkey::Pubkey,
+    pub holder_rewards_pool_token_account: solana_program::pubkey::Pubkey,
     /// Token mint.
     pub mint: solana_program::pubkey::Pubkey,
     /// System program.
@@ -33,7 +33,7 @@ impl InitializeHolderRewardsPool {
             false,
         ));
         accounts.push(solana_program::instruction::AccountMeta::new_readonly(
-            self.holder_rewards_pool_token_account_info,
+            self.holder_rewards_pool_token_account,
             false,
         ));
         accounts.push(solana_program::instruction::AccountMeta::new_readonly(
@@ -78,14 +78,14 @@ impl Default for InitializeHolderRewardsPoolInstructionData {
 /// ### Accounts:
 ///
 ///   0. `[writable]` holder_rewards_pool
-///   1. `[]` holder_rewards_pool_token_account_info
+///   1. `[]` holder_rewards_pool_token_account
 ///   2. `[]` mint
 ///   3. `[optional]` system_program (default to
 ///      `11111111111111111111111111111111`)
 #[derive(Clone, Debug, Default)]
 pub struct InitializeHolderRewardsPoolBuilder {
     holder_rewards_pool: Option<solana_program::pubkey::Pubkey>,
-    holder_rewards_pool_token_account_info: Option<solana_program::pubkey::Pubkey>,
+    holder_rewards_pool_token_account: Option<solana_program::pubkey::Pubkey>,
     mint: Option<solana_program::pubkey::Pubkey>,
     system_program: Option<solana_program::pubkey::Pubkey>,
     __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
@@ -106,11 +106,11 @@ impl InitializeHolderRewardsPoolBuilder {
     }
     /// Holder rewards pool token account.
     #[inline(always)]
-    pub fn holder_rewards_pool_token_account_info(
+    pub fn holder_rewards_pool_token_account(
         &mut self,
-        holder_rewards_pool_token_account_info: solana_program::pubkey::Pubkey,
+        holder_rewards_pool_token_account: solana_program::pubkey::Pubkey,
     ) -> &mut Self {
-        self.holder_rewards_pool_token_account_info = Some(holder_rewards_pool_token_account_info);
+        self.holder_rewards_pool_token_account = Some(holder_rewards_pool_token_account);
         self
     }
     /// Token mint.
@@ -126,7 +126,7 @@ impl InitializeHolderRewardsPoolBuilder {
         self.system_program = Some(system_program);
         self
     }
-    /// Add an aditional account to the instruction.
+    /// Add an additional account to the instruction.
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
@@ -150,9 +150,9 @@ impl InitializeHolderRewardsPoolBuilder {
             holder_rewards_pool: self
                 .holder_rewards_pool
                 .expect("holder_rewards_pool is not set"),
-            holder_rewards_pool_token_account_info: self
-                .holder_rewards_pool_token_account_info
-                .expect("holder_rewards_pool_token_account_info is not set"),
+            holder_rewards_pool_token_account: self
+                .holder_rewards_pool_token_account
+                .expect("holder_rewards_pool_token_account is not set"),
             mint: self.mint.expect("mint is not set"),
             system_program: self
                 .system_program
@@ -168,7 +168,7 @@ pub struct InitializeHolderRewardsPoolCpiAccounts<'a, 'b> {
     /// Holder rewards pool account.
     pub holder_rewards_pool: &'b solana_program::account_info::AccountInfo<'a>,
     /// Holder rewards pool token account.
-    pub holder_rewards_pool_token_account_info: &'b solana_program::account_info::AccountInfo<'a>,
+    pub holder_rewards_pool_token_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token mint.
     pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program.
@@ -182,7 +182,7 @@ pub struct InitializeHolderRewardsPoolCpi<'a, 'b> {
     /// Holder rewards pool account.
     pub holder_rewards_pool: &'b solana_program::account_info::AccountInfo<'a>,
     /// Holder rewards pool token account.
-    pub holder_rewards_pool_token_account_info: &'b solana_program::account_info::AccountInfo<'a>,
+    pub holder_rewards_pool_token_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token mint.
     pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program.
@@ -197,7 +197,7 @@ impl<'a, 'b> InitializeHolderRewardsPoolCpi<'a, 'b> {
         Self {
             __program: program,
             holder_rewards_pool: accounts.holder_rewards_pool,
-            holder_rewards_pool_token_account_info: accounts.holder_rewards_pool_token_account_info,
+            holder_rewards_pool_token_account: accounts.holder_rewards_pool_token_account,
             mint: accounts.mint,
             system_program: accounts.system_program,
         }
@@ -241,7 +241,7 @@ impl<'a, 'b> InitializeHolderRewardsPoolCpi<'a, 'b> {
             false,
         ));
         accounts.push(solana_program::instruction::AccountMeta::new_readonly(
-            *self.holder_rewards_pool_token_account_info.key,
+            *self.holder_rewards_pool_token_account.key,
             false,
         ));
         accounts.push(solana_program::instruction::AccountMeta::new_readonly(
@@ -271,7 +271,7 @@ impl<'a, 'b> InitializeHolderRewardsPoolCpi<'a, 'b> {
         let mut account_infos = Vec::with_capacity(4 + 1 + remaining_accounts.len());
         account_infos.push(self.__program.clone());
         account_infos.push(self.holder_rewards_pool.clone());
-        account_infos.push(self.holder_rewards_pool_token_account_info.clone());
+        account_infos.push(self.holder_rewards_pool_token_account.clone());
         account_infos.push(self.mint.clone());
         account_infos.push(self.system_program.clone());
         remaining_accounts
@@ -291,7 +291,7 @@ impl<'a, 'b> InitializeHolderRewardsPoolCpi<'a, 'b> {
 /// ### Accounts:
 ///
 ///   0. `[writable]` holder_rewards_pool
-///   1. `[]` holder_rewards_pool_token_account_info
+///   1. `[]` holder_rewards_pool_token_account
 ///   2. `[]` mint
 ///   3. `[]` system_program
 #[derive(Clone, Debug)]
@@ -304,7 +304,7 @@ impl<'a, 'b> InitializeHolderRewardsPoolCpiBuilder<'a, 'b> {
         let instruction = Box::new(InitializeHolderRewardsPoolCpiBuilderInstruction {
             __program: program,
             holder_rewards_pool: None,
-            holder_rewards_pool_token_account_info: None,
+            holder_rewards_pool_token_account: None,
             mint: None,
             system_program: None,
             __remaining_accounts: Vec::new(),
@@ -322,12 +322,12 @@ impl<'a, 'b> InitializeHolderRewardsPoolCpiBuilder<'a, 'b> {
     }
     /// Holder rewards pool token account.
     #[inline(always)]
-    pub fn holder_rewards_pool_token_account_info(
+    pub fn holder_rewards_pool_token_account(
         &mut self,
-        holder_rewards_pool_token_account_info: &'b solana_program::account_info::AccountInfo<'a>,
+        holder_rewards_pool_token_account: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
-        self.instruction.holder_rewards_pool_token_account_info =
-            Some(holder_rewards_pool_token_account_info);
+        self.instruction.holder_rewards_pool_token_account =
+            Some(holder_rewards_pool_token_account);
         self
     }
     /// Token mint.
@@ -395,10 +395,10 @@ impl<'a, 'b> InitializeHolderRewardsPoolCpiBuilder<'a, 'b> {
                 .holder_rewards_pool
                 .expect("holder_rewards_pool is not set"),
 
-            holder_rewards_pool_token_account_info: self
+            holder_rewards_pool_token_account: self
                 .instruction
-                .holder_rewards_pool_token_account_info
-                .expect("holder_rewards_pool_token_account_info is not set"),
+                .holder_rewards_pool_token_account
+                .expect("holder_rewards_pool_token_account is not set"),
 
             mint: self.instruction.mint.expect("mint is not set"),
 
@@ -418,8 +418,7 @@ impl<'a, 'b> InitializeHolderRewardsPoolCpiBuilder<'a, 'b> {
 struct InitializeHolderRewardsPoolCpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_program::account_info::AccountInfo<'a>,
     holder_rewards_pool: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    holder_rewards_pool_token_account_info:
-        Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    holder_rewards_pool_token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.

--- a/clients/rust/src/generated/instructions/withdraw.rs
+++ b/clients/rust/src/generated/instructions/withdraw.rs
@@ -25,12 +25,16 @@ pub struct Withdraw {
 }
 
 impl Withdraw {
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
-        self.instruction_with_remaining_accounts(&[])
+    pub fn instruction(
+        &self,
+        args: WithdrawInstructionArgs,
+    ) -> solana_program::instruction::Instruction {
+        self.instruction_with_remaining_accounts(args, &[])
     }
     #[allow(clippy::vec_init_then_push)]
     pub fn instruction_with_remaining_accounts(
         &self,
+        args: WithdrawInstructionArgs,
         remaining_accounts: &[solana_program::instruction::AccountMeta],
     ) -> solana_program::instruction::Instruction {
         let mut accounts = Vec::with_capacity(7 + remaining_accounts.len());
@@ -61,7 +65,9 @@ impl Withdraw {
             false,
         ));
         accounts.extend_from_slice(remaining_accounts);
-        let data = WithdrawInstructionData::new().try_to_vec().unwrap();
+        let mut data = WithdrawInstructionData::new().try_to_vec().unwrap();
+        let mut args = args.try_to_vec().unwrap();
+        data.append(&mut args);
 
         solana_program::instruction::Instruction {
             program_id: crate::PALADIN_REWARDS_ID,
@@ -88,6 +94,12 @@ impl Default for WithdrawInstructionData {
     }
 }
 
+#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct WithdrawInstructionArgs {
+    pub amount: u64,
+}
+
 /// Instruction builder for `Withdraw`.
 ///
 /// ### Accounts:
@@ -109,6 +121,7 @@ pub struct WithdrawBuilder {
     mint: Option<solana_program::pubkey::Pubkey>,
     owner: Option<solana_program::pubkey::Pubkey>,
     token_program: Option<solana_program::pubkey::Pubkey>,
+    amount: Option<u64>,
     __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
 }
 
@@ -165,6 +178,11 @@ impl WithdrawBuilder {
         self.token_program = Some(token_program);
         self
     }
+    #[inline(always)]
+    pub fn amount(&mut self, amount: u64) -> &mut Self {
+        self.amount = Some(amount);
+        self
+    }
     /// Add an aditional account to the instruction.
     #[inline(always)]
     pub fn add_remaining_account(
@@ -200,8 +218,11 @@ impl WithdrawBuilder {
                 "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
             )),
         };
+        let args = WithdrawInstructionArgs {
+            amount: self.amount.clone().expect("amount is not set"),
+        };
 
-        accounts.instruction_with_remaining_accounts(&self.__remaining_accounts)
+        accounts.instruction_with_remaining_accounts(args, &self.__remaining_accounts)
     }
 }
 
@@ -241,12 +262,15 @@ pub struct WithdrawCpi<'a, 'b> {
     pub owner: &'b solana_program::account_info::AccountInfo<'a>,
     /// token program
     pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
+    /// The arguments for the instruction.
+    pub __args: WithdrawInstructionArgs,
 }
 
 impl<'a, 'b> WithdrawCpi<'a, 'b> {
     pub fn new(
         program: &'b solana_program::account_info::AccountInfo<'a>,
         accounts: WithdrawCpiAccounts<'a, 'b>,
+        args: WithdrawInstructionArgs,
     ) -> Self {
         Self {
             __program: program,
@@ -257,6 +281,7 @@ impl<'a, 'b> WithdrawCpi<'a, 'b> {
             mint: accounts.mint,
             owner: accounts.owner,
             token_program: accounts.token_program,
+            __args: args,
         }
     }
     #[inline(always)]
@@ -328,7 +353,9 @@ impl<'a, 'b> WithdrawCpi<'a, 'b> {
                 is_writable: remaining_account.2,
             })
         });
-        let data = WithdrawInstructionData::new().try_to_vec().unwrap();
+        let mut data = WithdrawInstructionData::new().try_to_vec().unwrap();
+        let mut args = self.__args.try_to_vec().unwrap();
+        data.append(&mut args);
 
         let instruction = solana_program::instruction::Instruction {
             program_id: crate::PALADIN_REWARDS_ID,
@@ -383,6 +410,7 @@ impl<'a, 'b> WithdrawCpiBuilder<'a, 'b> {
             mint: None,
             owner: None,
             token_program: None,
+            amount: None,
             __remaining_accounts: Vec::new(),
         });
         Self { instruction }
@@ -445,6 +473,11 @@ impl<'a, 'b> WithdrawCpiBuilder<'a, 'b> {
         self.instruction.token_program = Some(token_program);
         self
     }
+    #[inline(always)]
+    pub fn amount(&mut self, amount: u64) -> &mut Self {
+        self.instruction.amount = Some(amount);
+        self
+    }
     /// Add an additional account to the instruction.
     #[inline(always)]
     pub fn add_remaining_account(
@@ -487,6 +520,9 @@ impl<'a, 'b> WithdrawCpiBuilder<'a, 'b> {
         &self,
         signers_seeds: &[&[&[u8]]],
     ) -> solana_program::entrypoint::ProgramResult {
+        let args = WithdrawInstructionArgs {
+            amount: self.instruction.amount.clone().expect("amount is not set"),
+        };
         let instruction = WithdrawCpi {
             __program: self.instruction.__program,
 
@@ -518,6 +554,7 @@ impl<'a, 'b> WithdrawCpiBuilder<'a, 'b> {
                 .instruction
                 .token_program
                 .expect("token_program is not set"),
+            __args: args,
         };
         instruction.invoke_signed_with_remaining_accounts(
             signers_seeds,
@@ -536,6 +573,7 @@ struct WithdrawCpiBuilderInstruction<'a, 'b> {
     mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     owner: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    amount: Option<u64>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
     __remaining_accounts: Vec<(
         &'b solana_program::account_info::AccountInfo<'a>,

--- a/clients/rust/src/generated/instructions/withdraw.rs
+++ b/clients/rust/src/generated/instructions/withdraw.rs
@@ -57,7 +57,7 @@ impl Withdraw {
         accounts.push(solana_program::instruction::AccountMeta::new_readonly(
             self.mint, false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_program::instruction::AccountMeta::new(
             self.owner, true,
         ));
         accounts.push(solana_program::instruction::AccountMeta::new_readonly(
@@ -109,7 +109,7 @@ pub struct WithdrawInstructionArgs {
 ///   2. `[writable]` holder_rewards
 ///   3. `[writable]` token_account
 ///   4. `[]` mint
-///   5. `[signer]` owner
+///   5. `[writable, signer]` owner
 ///   6. `[optional]` token_program (default to
 ///      `TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA`)
 #[derive(Clone, Debug, Default)]
@@ -183,7 +183,7 @@ impl WithdrawBuilder {
         self.amount = Some(amount);
         self
     }
-    /// Add an aditional account to the instruction.
+    /// Add an additional account to the instruction.
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
@@ -338,7 +338,7 @@ impl<'a, 'b> WithdrawCpi<'a, 'b> {
             *self.mint.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_program::instruction::AccountMeta::new(
             *self.owner.key,
             true,
         ));
@@ -392,7 +392,7 @@ impl<'a, 'b> WithdrawCpi<'a, 'b> {
 ///   2. `[writable]` holder_rewards
 ///   3. `[writable]` token_account
 ///   4. `[]` mint
-///   5. `[signer]` owner
+///   5. `[writable, signer]` owner
 ///   6. `[]` token_program
 #[derive(Clone, Debug)]
 pub struct WithdrawCpiBuilder<'a, 'b> {

--- a/package.json
+++ b/package.json
@@ -24,11 +24,11 @@
   },
   "devDependencies": {
     "@iarna/toml": "^2.2.5",
-    "@kinobi-so/nodes-from-anchor": "^0.20.9",
-    "@kinobi-so/renderers-js": "^0.21.2",
-    "@kinobi-so/renderers-rust": "^0.21.0",
+    "@kinobi-so/nodes-from-anchor": "^0.22.0",
+    "@kinobi-so/renderers-js": "^0.22.0",
+    "@kinobi-so/renderers-rust": "^0.22.0",
     "@metaplex-foundation/shank-js": "^0.1.7",
-    "kinobi": "^0.21.0",
+    "kinobi": "^0.22.0",
     "typescript": "^5.5.2",
     "zx": "^7.2.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,20 +12,20 @@ importers:
         specifier: ^2.2.5
         version: 2.2.5
       '@kinobi-so/nodes-from-anchor':
-        specifier: ^0.20.9
-        version: 0.20.9
+        specifier: ^0.22.0
+        version: 0.22.0
       '@kinobi-so/renderers-js':
-        specifier: ^0.21.2
-        version: 0.21.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.4)
+        specifier: ^0.22.0
+        version: 0.22.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.4)
       '@kinobi-so/renderers-rust':
-        specifier: ^0.21.0
-        version: 0.21.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.4)
+        specifier: ^0.22.0
+        version: 0.22.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.4)
       '@metaplex-foundation/shank-js':
         specifier: ^0.1.7
         version: 0.1.7
       kinobi:
-        specifier: ^0.21.0
-        version: 0.21.0
+        specifier: ^0.22.0
+        version: 0.22.0
       typescript:
         specifier: ^5.5.2
         version: 5.5.4
@@ -38,36 +38,36 @@ packages:
   '@iarna/toml@2.2.5':
     resolution: {integrity: sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==}
 
-  '@kinobi-so/errors@0.21.0':
-    resolution: {integrity: sha512-7dPK35L/Y01qzekhVHdKAu+lENmHhuwX39rIx3qNJpNPHKi1VCcorLuOJlfT2F9MPPUjv5pZliL5qQ5IsvtNMw==}
+  '@kinobi-so/errors@0.22.0':
+    resolution: {integrity: sha512-E78W0dR5X0fqRcEVsYRlI/wICIIIVa3ACzZEf2KLrUgOdnQ7U2xqtfnbKGlildnejR/43RgqKw67nYy8cQwpyA==}
     hasBin: true
 
-  '@kinobi-so/node-types@0.21.0':
-    resolution: {integrity: sha512-UmzjocmsLa1pZ/ExVklGRsWQZNoIvifKBuTEAcpdxlDhg6hmrMWoXwWvRrLI5o7v1WKvTucv7KuM+5GU9UhFDw==}
+  '@kinobi-so/node-types@0.22.0':
+    resolution: {integrity: sha512-vC/0eBV+L+ILTQG0Kyk0QcNZR7Vl2sK+a93/bKFJyjJVQ0rDikOwcquYRFQtfovQD0zOjPJddkGPb2N03JgaNQ==}
 
-  '@kinobi-so/nodes-from-anchor@0.20.9':
-    resolution: {integrity: sha512-xNlwvJek6Hbfi45Unocwq/lT3rFXhmpZcAZmQJMgdIH8E4iAya9ZQ89j4neRQ+C1KVrK9qFJh0SaJvt9xnJQXA==}
+  '@kinobi-so/nodes-from-anchor@0.22.0':
+    resolution: {integrity: sha512-QNBZ5bxWl24jJQ+DwcAuMulawxW0B0Q2eEMrauFgXIa5ztXw4txIVydkwSaOdTivE2yhQXR06pg5jLIF/zJ3Rw==}
 
-  '@kinobi-so/nodes@0.21.0':
-    resolution: {integrity: sha512-Z8STFjB3/f9LzK494l6qydkBMsFtnm96YreJjlAg9/DeKNtphimslSvFTF/9qHiGMfOQpOVhQqbWFXpt+PCZiQ==}
+  '@kinobi-so/nodes@0.22.0':
+    resolution: {integrity: sha512-wsLr36s0sYS8zQ9x9TOeaxhLW+T/revpbXhpZTTqb/2L+CGINtuvUgxzQWKHPzLpomRje/1yqwOYpj5QXY3CLg==}
 
-  '@kinobi-so/renderers-core@0.20.7':
-    resolution: {integrity: sha512-KJhU8+UMowO9dDkLhEodAkbRkgSxdfBWeY+DIgOCgXcakt0T140K7OREuaAo9fp12Owf+10SAEGx9AzTNySoHA==}
+  '@kinobi-so/renderers-core@0.22.0':
+    resolution: {integrity: sha512-m151uCRuCsgzA7mdT+3GYVzpct4h7dEGydda+h6UDbsuk7dcA6aVx4OVXYhF0TY/xKhw4MTBzluvwrcAZzFzMA==}
 
-  '@kinobi-so/renderers-js@0.21.2':
-    resolution: {integrity: sha512-G576GAQ10ugmA63EZRlEbv892th37q9ow+AMzZD1vtypRCEJ7znakzySSDG3aeqaZujk2igKXFQTD+FHuY/xPg==}
+  '@kinobi-so/renderers-js@0.22.0':
+    resolution: {integrity: sha512-ASgjgXbTmKLf8SWQlTJe5RKqpe/t0Jk0AQ2pN1yWfF1AiT8ogMjHnkV1yYDJ5oqCNiAnwO4R6TS8bzE77AEFjw==}
 
-  '@kinobi-so/renderers-rust@0.21.0':
-    resolution: {integrity: sha512-BLe1SW6XFBhjtZdCc7cuukMWrJTbhCafCCmXryLmjzF7jaiK9nyZZFinHxljSac4HCk2vDn22mHAwOjabaDQ2Q==}
+  '@kinobi-so/renderers-rust@0.22.0':
+    resolution: {integrity: sha512-1tgbWWivfXepZefwVTwvYfzlebUILmDGRMI/9t6bYNPDh1G0UqH0aHig2qm8bKUIMBiU0wmnFLOAkCCcmld3Cw==}
 
-  '@kinobi-so/validators@0.21.0':
-    resolution: {integrity: sha512-mpBqgqlto/Wdj6rlf1mqWkyw00rPJw98bkNItXq+ofCEtBsjaMq9lsevCE+IPmfJJYEPFGHGJW4Gb6m/cLmOqw==}
+  '@kinobi-so/validators@0.22.0':
+    resolution: {integrity: sha512-sx03aFRyvOxfx6pCjPF/W7hpzU4buylkhZXd1/HqRIHJz17DMvWDV4y6uczb3mDroVj4J2Wq+2XWlwGU9H3FBg==}
 
-  '@kinobi-so/visitors-core@0.21.0':
-    resolution: {integrity: sha512-m6C/cAy7q7ZAWhByQGo2YnBsbt0qS3Un0lyT4mmPGQt0QFXUDExFipjTvY/NnzZ5lQJ2grvnL04pqLx8V7eiuw==}
+  '@kinobi-so/visitors-core@0.22.0':
+    resolution: {integrity: sha512-PM9UNzWEAHjctgtR7qZFeGAqQWxVqfidVbYMFcRxUvd411+Yj+i0ByrHBe8J2N7mwlwiqYwcDBJDLE2Yr2ljuw==}
 
-  '@kinobi-so/visitors@0.21.0':
-    resolution: {integrity: sha512-gigysLJCfVtNCFkdDMeHGB+1SOvoiQOPUVKxewzOq1wDYVioFmmf4aXfB1GCEslLlMvl63cTJrwvh8bDIZoaSA==}
+  '@kinobi-so/visitors@0.22.0':
+    resolution: {integrity: sha512-BN1CKgSmZ+pLKAao2YDfo2cqS6TLxGaxgqAL7oeItlKSZdOAoJMmieER7EE7pqQODRzLmnLKLeHmnYSc4kg/Fw==}
 
   '@metaplex-foundation/rustbin@0.3.5':
     resolution: {integrity: sha512-m0wkRBEQB/8krwMwKBvFugufZtYwMXiGHud2cTDAv+aGXK4M90y0Hx67/wpu+AqqoQfdV8VM9YezUOHKD+Z5kA==}
@@ -75,9 +75,9 @@ packages:
   '@metaplex-foundation/shank-js@0.1.7':
     resolution: {integrity: sha512-tSAipn8Ho1UxlMC3jwJ5Opl+Y3lRm60VTkgRDfvzydb57lXW5G+K5MrZhEmhrFUuRYziV+e34CTo+ybpMp1Eqg==}
 
-  '@noble/hashes@1.4.0':
-    resolution: {integrity: sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==}
-    engines: {node: '>= 16'}
+  '@noble/hashes@1.8.0':
+    resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
+    engines: {node: ^14.21.3 || >=16}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -91,24 +91,28 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@solana/codecs-core@2.0.0-preview.4':
-    resolution: {integrity: sha512-A0VVuDDA5kNKZUinOqHxJQK32aKTucaVbvn31YenGzHX1gPqq+SOnFwgaEY6pq4XEopSmaK16w938ZQS8IvCnw==}
+  '@solana/codecs-core@2.0.0-rc.4':
+    resolution: {integrity: sha512-JIrTSps032mSE3wBxW3bXOqWfoy4CMy1CX/XeVCijyh5kLVxZTSDIdRTYdePdL1yzaOZF1Xysvt1DhOUgBdM+A==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/codecs-numbers@2.0.0-preview.4':
-    resolution: {integrity: sha512-Q061rLtMadsO7uxpguT+Z7G4UHnjQ6moVIxAQxR58nLxDPCC7MB1Pk106/Z7NDhDLHTcd18uO6DZ7ajHZEn2XQ==}
+  '@solana/codecs-numbers@2.0.0-rc.4':
+    resolution: {integrity: sha512-ZJR7TaUO65+3Hzo3YOOUCS0wlzh17IW+j0MZC2LCk1R0woaypRpHKj4iSMYeQOZkMxsd9QT3WNvjFrPC2qA6Sw==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/codecs-strings@2.0.0-preview.4':
-    resolution: {integrity: sha512-YDbsQePRWm+xnrfS64losSGRg8Wb76cjK1K6qfR8LPmdwIC3787x9uW5/E4icl/k+9nwgbIRXZ65lpF+ucZUnw==}
+  '@solana/codecs-strings@2.0.0-rc.4':
+    resolution: {integrity: sha512-LGfK2RL0BKjYYUfzu2FG/gTgCsYOMz9FKVs2ntji6WneZygPxJTV5W98K3J8Rl0JewpCSCFQH3xjLSHBJUS0fA==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       fastestsmallesttextencoderdecoder: ^1.0.22
       typescript: '>=5'
 
-  '@solana/errors@2.0.0-preview.4':
-    resolution: {integrity: sha512-kadtlbRv2LCWr8A9V22On15Us7Nn8BvqNaOB4hXsTB3O0fU40D1ru2l+cReqLcRPij4znqlRzW9Xi0m6J5DIhA==}
+  '@solana/errors@2.0.0-rc.4':
+    resolution: {integrity: sha512-0PPaMyB81keEHG/1pnyEuiBVKctbXO641M2w3CIOrYT/wzjunfF0FTxsqq9wYJeYo0AyiefCKGgSPs6wiY2PpQ==}
+    engines: {node: '>=20.18.0'}
     hasBin: true
     peerDependencies:
       typescript: '>=5'
@@ -297,8 +301,8 @@ packages:
   jsonify@0.0.1:
     resolution: {integrity: sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==}
 
-  kinobi@0.21.0:
-    resolution: {integrity: sha512-T71VNh4yS8uSvtNp1FEWhJGygW5/8O82SAlFRlPYsWiwqWH9X3eZwwUthBVH7dfazqs8GLia0rAMEmUP99iwLw==}
+  kinobi@0.22.0:
+    resolution: {integrity: sha512-qhYuzfWXC7KgORs/jvY9vJE+jmD6xhI5QUiXTnQk8D+VyBt0Geuc1ZbZ1PRI69SOO7CAX9Bc0i0tTrtb09Z/Kg==}
 
   map-stream@0.1.0:
     resolution: {integrity: sha512-CkYQrPYZfWnu/DAmVCpTSX/xHpKZ80eKh2lAkyA6AJTef6bW+6JpbQZN5rofum7da+SyN1bi5ctTm+lTfcCW3g==}
@@ -441,40 +445,40 @@ snapshots:
 
   '@iarna/toml@2.2.5': {}
 
-  '@kinobi-so/errors@0.21.0':
+  '@kinobi-so/errors@0.22.0':
     dependencies:
-      '@kinobi-so/node-types': 0.21.0
+      '@kinobi-so/node-types': 0.22.0
       chalk: 5.3.0
       commander: 12.1.0
 
-  '@kinobi-so/node-types@0.21.0': {}
+  '@kinobi-so/node-types@0.22.0': {}
 
-  '@kinobi-so/nodes-from-anchor@0.20.9':
+  '@kinobi-so/nodes-from-anchor@0.22.0':
     dependencies:
-      '@kinobi-so/errors': 0.21.0
-      '@kinobi-so/nodes': 0.21.0
-      '@kinobi-so/visitors': 0.21.0
-      '@noble/hashes': 1.4.0
+      '@kinobi-so/errors': 0.22.0
+      '@kinobi-so/nodes': 0.22.0
+      '@kinobi-so/visitors': 0.22.0
+      '@noble/hashes': 1.8.0
 
-  '@kinobi-so/nodes@0.21.0':
+  '@kinobi-so/nodes@0.22.0':
     dependencies:
-      '@kinobi-so/errors': 0.21.0
-      '@kinobi-so/node-types': 0.21.0
+      '@kinobi-so/errors': 0.22.0
+      '@kinobi-so/node-types': 0.22.0
 
-  '@kinobi-so/renderers-core@0.20.7':
+  '@kinobi-so/renderers-core@0.22.0':
     dependencies:
-      '@kinobi-so/errors': 0.21.0
-      '@kinobi-so/nodes': 0.21.0
-      '@kinobi-so/visitors-core': 0.21.0
+      '@kinobi-so/errors': 0.22.0
+      '@kinobi-so/nodes': 0.22.0
+      '@kinobi-so/visitors-core': 0.22.0
 
-  '@kinobi-so/renderers-js@0.21.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.4)':
+  '@kinobi-so/renderers-js@0.22.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.4)':
     dependencies:
-      '@kinobi-so/errors': 0.21.0
-      '@kinobi-so/nodes': 0.21.0
-      '@kinobi-so/nodes-from-anchor': 0.20.9
-      '@kinobi-so/renderers-core': 0.20.7
-      '@kinobi-so/visitors-core': 0.21.0
-      '@solana/codecs-strings': 2.0.0-preview.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.4)
+      '@kinobi-so/errors': 0.22.0
+      '@kinobi-so/nodes': 0.22.0
+      '@kinobi-so/nodes-from-anchor': 0.22.0
+      '@kinobi-so/renderers-core': 0.22.0
+      '@kinobi-so/visitors-core': 0.22.0
+      '@solana/codecs-strings': 2.0.0-rc.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.4)
       nunjucks: 3.2.4
       prettier: 3.3.3
     transitivePeerDependencies:
@@ -482,36 +486,36 @@ snapshots:
       - fastestsmallesttextencoderdecoder
       - typescript
 
-  '@kinobi-so/renderers-rust@0.21.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.4)':
+  '@kinobi-so/renderers-rust@0.22.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.4)':
     dependencies:
-      '@kinobi-so/errors': 0.21.0
-      '@kinobi-so/nodes': 0.21.0
-      '@kinobi-so/renderers-core': 0.20.7
-      '@kinobi-so/visitors-core': 0.21.0
-      '@solana/codecs-strings': 2.0.0-preview.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.4)
+      '@kinobi-so/errors': 0.22.0
+      '@kinobi-so/nodes': 0.22.0
+      '@kinobi-so/renderers-core': 0.22.0
+      '@kinobi-so/visitors-core': 0.22.0
+      '@solana/codecs-strings': 2.0.0-rc.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.4)
       nunjucks: 3.2.4
     transitivePeerDependencies:
       - chokidar
       - fastestsmallesttextencoderdecoder
       - typescript
 
-  '@kinobi-so/validators@0.21.0':
+  '@kinobi-so/validators@0.22.0':
     dependencies:
-      '@kinobi-so/errors': 0.21.0
-      '@kinobi-so/nodes': 0.21.0
-      '@kinobi-so/visitors-core': 0.21.0
+      '@kinobi-so/errors': 0.22.0
+      '@kinobi-so/nodes': 0.22.0
+      '@kinobi-so/visitors-core': 0.22.0
 
-  '@kinobi-so/visitors-core@0.21.0':
+  '@kinobi-so/visitors-core@0.22.0':
     dependencies:
-      '@kinobi-so/errors': 0.21.0
-      '@kinobi-so/nodes': 0.21.0
+      '@kinobi-so/errors': 0.22.0
+      '@kinobi-so/nodes': 0.22.0
       json-stable-stringify: 1.1.1
 
-  '@kinobi-so/visitors@0.21.0':
+  '@kinobi-so/visitors@0.22.0':
     dependencies:
-      '@kinobi-so/errors': 0.21.0
-      '@kinobi-so/nodes': 0.21.0
-      '@kinobi-so/visitors-core': 0.21.0
+      '@kinobi-so/errors': 0.22.0
+      '@kinobi-so/nodes': 0.22.0
+      '@kinobi-so/visitors-core': 0.22.0
 
   '@metaplex-foundation/rustbin@0.3.5':
     dependencies:
@@ -530,7 +534,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@noble/hashes@1.4.0': {}
+  '@noble/hashes@1.8.0': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -544,26 +548,26 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.17.1
 
-  '@solana/codecs-core@2.0.0-preview.4(typescript@5.5.4)':
+  '@solana/codecs-core@2.0.0-rc.4(typescript@5.5.4)':
     dependencies:
-      '@solana/errors': 2.0.0-preview.4(typescript@5.5.4)
+      '@solana/errors': 2.0.0-rc.4(typescript@5.5.4)
       typescript: 5.5.4
 
-  '@solana/codecs-numbers@2.0.0-preview.4(typescript@5.5.4)':
+  '@solana/codecs-numbers@2.0.0-rc.4(typescript@5.5.4)':
     dependencies:
-      '@solana/codecs-core': 2.0.0-preview.4(typescript@5.5.4)
-      '@solana/errors': 2.0.0-preview.4(typescript@5.5.4)
+      '@solana/codecs-core': 2.0.0-rc.4(typescript@5.5.4)
+      '@solana/errors': 2.0.0-rc.4(typescript@5.5.4)
       typescript: 5.5.4
 
-  '@solana/codecs-strings@2.0.0-preview.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.4)':
+  '@solana/codecs-strings@2.0.0-rc.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.4)':
     dependencies:
-      '@solana/codecs-core': 2.0.0-preview.4(typescript@5.5.4)
-      '@solana/codecs-numbers': 2.0.0-preview.4(typescript@5.5.4)
-      '@solana/errors': 2.0.0-preview.4(typescript@5.5.4)
+      '@solana/codecs-core': 2.0.0-rc.4(typescript@5.5.4)
+      '@solana/codecs-numbers': 2.0.0-rc.4(typescript@5.5.4)
+      '@solana/errors': 2.0.0-rc.4(typescript@5.5.4)
       fastestsmallesttextencoderdecoder: 1.0.22
       typescript: 5.5.4
 
-  '@solana/errors@2.0.0-preview.4(typescript@5.5.4)':
+  '@solana/errors@2.0.0-rc.4(typescript@5.5.4)':
     dependencies:
       chalk: 5.3.0
       commander: 12.1.0
@@ -752,12 +756,12 @@ snapshots:
 
   jsonify@0.0.1: {}
 
-  kinobi@0.21.0:
+  kinobi@0.22.0:
     dependencies:
-      '@kinobi-so/errors': 0.21.0
-      '@kinobi-so/nodes': 0.21.0
-      '@kinobi-so/validators': 0.21.0
-      '@kinobi-so/visitors': 0.21.0
+      '@kinobi-so/errors': 0.22.0
+      '@kinobi-so/nodes': 0.22.0
+      '@kinobi-so/validators': 0.22.0
+      '@kinobi-so/visitors': 0.22.0
 
   map-stream@0.1.0: {}
 

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -22,7 +22,6 @@ spl-associated-token-account = { version = "4.0.0", features = [
 spl-token = { version = "4.0.0", features = ["no-entrypoint"] }
 thiserror = "1.0"
 
-
 [dev-dependencies]
 proptest = "1.5.0"
 solana-program-test = "2.1.4"

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -13,6 +13,7 @@ arrayref = "0.3.7"
 bytemuck = "1.16.0"
 num-derive = "0.3"
 num-traits = "0.2"
+paladin-rewards-program-client = { path = "../clients/rust" }
 shank = "0.4.2"
 solana-program = "2.1.4"
 spl-associated-token-account = { version = "4.0.0", features = [
@@ -20,7 +21,7 @@ spl-associated-token-account = { version = "4.0.0", features = [
 ] }
 spl-token = { version = "4.0.0", features = ["no-entrypoint"] }
 thiserror = "1.0"
-paladin-rewards-program-client = {path = "../clients/rust"}
+
 
 [dev-dependencies]
 proptest = "1.5.0"

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -20,6 +20,7 @@ spl-associated-token-account = { version = "4.0.0", features = [
 ] }
 spl-token = { version = "4.0.0", features = ["no-entrypoint"] }
 thiserror = "1.0"
+paladin-rewards-program-client = {path = "../clients/rust"}
 
 [dev-dependencies]
 proptest = "1.5.0"

--- a/program/idl.json
+++ b/program/idl.json
@@ -14,7 +14,7 @@
           ]
         },
         {
-          "name": "holderRewardsPoolTokenAccountInfo",
+          "name": "holderRewardsPoolTokenAccount",
           "isMut": false,
           "isSigner": false,
           "docs": [
@@ -56,7 +56,7 @@
           ]
         },
         {
-          "name": "holderRewardsPoolTokenAccountInfo",
+          "name": "holderRewardsPoolTokenAccount",
           "isMut": false,
           "isSigner": false,
           "docs": [
@@ -114,7 +114,7 @@
           ]
         },
         {
-          "name": "holderRewardsPoolTokenAccountInfo",
+          "name": "holderRewardsPoolTokenAccount",
           "isMut": false,
           "isSigner": false,
           "docs": [
@@ -164,7 +164,7 @@
           ]
         },
         {
-          "name": "holderRewardsPoolTokenAccountInfo",
+          "name": "holderRewardsPoolTokenAccount",
           "isMut": true,
           "isSigner": false,
           "docs": [
@@ -177,14 +177,6 @@
           "isSigner": false,
           "docs": [
             "Holder rewards account."
-          ]
-        },
-        {
-          "name": "tokenAccount",
-          "isMut": false,
-          "isSigner": false,
-          "docs": [
-            "Token account."
           ]
         },
         {
@@ -255,7 +247,7 @@
         },
         {
           "name": "owner",
-          "isMut": false,
+          "isMut": true,
           "isSigner": true,
           "docs": [
             "Owner of the account."
@@ -326,7 +318,7 @@
         },
         {
           "name": "owner",
-          "isMut": false,
+          "isMut": true,
           "isSigner": true,
           "docs": [
             "Owner of the account."

--- a/program/idl.json
+++ b/program/idl.json
@@ -223,7 +223,7 @@
         },
         {
           "name": "holderRewardsPoolTokenAccount",
-          "isMut": false,
+          "isMut": true,
           "isSigner": false,
           "docs": [
             "Holder rewards pool token account."

--- a/program/idl.json
+++ b/program/idl.json
@@ -341,7 +341,12 @@
           ]
         }
       ],
-      "args": [],
+      "args": [
+        {
+          "name": "amount",
+          "type": "u64"
+        }
+      ],
       "discriminant": {
         "type": "u8",
         "value": 5
@@ -460,6 +465,11 @@
       "code": 13,
       "name": "NotEnoughTokenToDeposit",
       "msg": "Owner doesn'thave enough tokens to deposit"
+    },
+    {
+      "code": 14,
+      "name": "WithdrawExceedsDeposited",
+      "msg": "Withdraw amount exceeds deposited"
     }
   ],
   "metadata": {

--- a/program/src/error.rs
+++ b/program/src/error.rs
@@ -56,6 +56,9 @@ pub enum PaladinRewardsError {
     /// Owner doesn'thave enough tokens to deposit.
     #[error("Owner doesn'thave enough tokens to deposit")]
     NotEnoughTokenToDeposit,
+    /// Withdraw amount exceeds deposited
+    #[error("Withdraw amount exceeds deposited")]
+    WithdrawExceedsDeposited,
 }
 
 impl PrintProgramError for PaladinRewardsError {

--- a/program/src/error.rs
+++ b/program/src/error.rs
@@ -14,49 +14,50 @@ use {
 // Note: Shank does not export the type when we use `spl_program_error`.
 #[derive(Error, Clone, Debug, Eq, PartialEq, FromPrimitive)]
 pub enum PaladinRewardsError {
-    /// Incorrect holder rewards pool address.
+    /// 0 - Incorrect holder rewards pool address.
     #[error("Incorrect holder rewards pool address")]
     IncorrectHolderRewardsPoolAddress,
-    /// Incorrect holder rewards address.
+    /// 1 - Incorrect holder rewards address.
     #[error("Incorrect holder rewards address")]
     IncorrectHolderRewardsAddress,
-    /// Token account mint mismatch.
+    /// 2 - Token account mint mismatch.
     #[error("Token account mint mismatch")]
     TokenAccountMintMismatch,
-    /// Attempted to close a holder rewards account that had unclaimed rewards.
+    /// 3 - Attempted to close a holder rewards account that had unclaimed
+    /// rewards.
     #[error("Holder rewards has unclaimed rewards")]
     CloseWithUnclaimedRewards,
-    /// Cannot close holder rewards with current balance.
+    /// 4 - Cannot close holder rewards with current balance.
     #[error("Cannot close holder rewards with current balance")]
     InvalidClosingBalance,
-    /// Owner is not the signer.
+    /// 5 - Owner is not the signer.
     #[error("Owner is not the signer")]
     OwnerNotSigner,
-    /// Signer not owner of token account.
+    /// 6 - Signer not owner of token account.
     #[error("Signer not owner of token account")]
     NotOwnerTokenAccount,
-    /// Rewards amount exceeds pool balance.
+    /// 7 - Rewards amount exceeds pool balance.
     #[error("Rewards amount exceeds pool balance")]
     RewardsExcessPoolBalance,
-    /// Holder rewards has deposited tokens.
+    /// 8 - Holder rewards has deposited tokens.
     #[error("Holder rewards has deposited tokens")]
     CloseWithDepositedTokens,
-    /// Holder doesn't have any deposited tokens to withdraw.
+    /// 9 - Holder doesn't have any deposited tokens to withdraw.
     #[error("Holder doesn't have any deposited tokens to withdraw")]
     NoDepositedTokensToWithdraw,
-    /// Pool doesn't have enough balance to withdraw.
+    /// 10 - Pool doesn't have enough balance to withdraw.
     #[error("Pool doesn't have enough balance to withdraw")]
     WithdrawExceedsPoolBalance,
-    /// Token account owner mismatch.
+    /// 11 - Token account owner mismatch.
     #[error("Token account owner mismatch")]
     TokenAccountOwnerMissmatch,
-    /// Token account is frozen.
+    /// 12 - Token account is frozen.
     #[error("Token account is frozen")]
     TokenAccountFrozen,
-    /// Owner doesn'thave enough tokens to deposit.
+    /// 13 - Owner doesn'thave enough tokens to deposit.
     #[error("Owner doesn'thave enough tokens to deposit")]
     NotEnoughTokenToDeposit,
-    /// Withdraw amount exceeds deposited
+    /// 14 - Withdraw amount exceeds deposited
     #[error("Withdraw amount exceeds deposited")]
     WithdrawExceedsDeposited,
 }

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -1,15 +1,6 @@
 //! Program instruction types.
 
-use {
-    arrayref::array_ref,
-    shank::ShankInstruction,
-    solana_program::{
-        instruction::{AccountMeta, Instruction},
-        program_error::ProgramError,
-        pubkey::Pubkey,
-        system_program,
-    },
-};
+use {arrayref::array_ref, shank::ShankInstruction, solana_program::program_error::ProgramError};
 
 /// Instructions supported by the Paladin Rewards program.
 #[rustfmt::skip]
@@ -38,7 +29,7 @@ pub enum PaladinRewardsInstruction {
     )]
     #[account(
         1,
-        name = "holder_rewards_pool_token_account_info",
+        name = "holder_rewards_pool_token_account",
         desc = "Holder rewards pool token account."
     )]
     #[account(
@@ -73,7 +64,7 @@ pub enum PaladinRewardsInstruction {
     )]
     #[account(
         1,
-        name = "holder_rewards_pool_token_account_info",
+        name = "holder_rewards_pool_token_account",
         desc = "Holder rewards pool token account."
     )]
     #[account(
@@ -119,7 +110,7 @@ pub enum PaladinRewardsInstruction {
     )]
     #[account(
         1,
-        name = "holder_rewards_pool_token_account_info",
+        name = "holder_rewards_pool_token_account",
         desc = "Holder rewards pool token account."
     )]
     #[account(
@@ -151,7 +142,7 @@ pub enum PaladinRewardsInstruction {
     #[account(
         1,
         writable,
-        name = "holder_rewards_pool_token_account_info",
+        name = "holder_rewards_pool_token_account",
         desc = "Holder rewards pool token account."
     )]
     #[account(
@@ -162,16 +153,11 @@ pub enum PaladinRewardsInstruction {
     )]
     #[account(
         3,
-        name = "token_account",
-        desc = "Token account.",
-    )]
-    #[account(
-        4,
         name = "mint",
         desc = "Token mint.",
     )]
     #[account(
-        5,
+        4,
         signer,
         writable,
         name = "owner",
@@ -209,6 +195,7 @@ pub enum PaladinRewardsInstruction {
     )]
     #[account(
         5,
+        writable,
         signer,
         name = "owner",
         desc = "Owner of the account.",
@@ -250,6 +237,7 @@ pub enum PaladinRewardsInstruction {
     )]
     #[account(
         5,
+        writable,
         signer,
         name = "owner",
         desc = "Owner of the account.",
@@ -308,132 +296,6 @@ impl PaladinRewardsInstruction {
             _ => Err(ProgramError::InvalidInstructionData),
         }
     }
-}
-
-/// Creates an
-/// [InitializeHolderRewardsPool](enum.PaladinRewardsInstruction.html)
-/// instruction.
-pub fn initialize_holder_rewards_pool(
-    holder_rewards_pool_address: &Pubkey,
-    holder_rewards_pool_token_account_address: &Pubkey,
-    mint_address: &Pubkey,
-) -> Instruction {
-    let accounts = vec![
-        AccountMeta::new(*holder_rewards_pool_address, false),
-        AccountMeta::new(*holder_rewards_pool_token_account_address, false),
-        AccountMeta::new_readonly(*mint_address, false),
-        AccountMeta::new_readonly(system_program::id(), false),
-    ];
-    let data = PaladinRewardsInstruction::InitializeHolderRewardsPool.pack();
-    Instruction::new_with_bytes(crate::id(), &data, accounts)
-}
-
-/// Creates an [InitializeHolderRewards](enum.PaladinRewardsInstruction.html)
-/// instruction.
-pub fn initialize_holder_rewards(
-    holder_rewards_pool_address: &Pubkey,
-    holder_rewards_pool_token_account_address: &Pubkey,
-    holder_rewards_address: &Pubkey,
-    owner: &Pubkey,
-    mint_address: &Pubkey,
-) -> Instruction {
-    let accounts = vec![
-        AccountMeta::new(*holder_rewards_pool_address, false),
-        AccountMeta::new_readonly(*holder_rewards_pool_token_account_address, false),
-        AccountMeta::new(*owner, true),
-        AccountMeta::new(*holder_rewards_address, false),
-        AccountMeta::new_readonly(*mint_address, false),
-        AccountMeta::new_readonly(system_program::id(), false),
-    ];
-    let data = PaladinRewardsInstruction::InitializeHolderRewards.pack();
-    Instruction::new_with_bytes(crate::id(), &data, accounts)
-}
-
-/// Creates a [HarvestRewards](enum.PaladinRewardsInstruction.html) instruction.
-pub fn harvest_rewards(
-    holder_rewards_pool_address: &Pubkey,
-    holder_rewards_pool_token_account_address: &Pubkey,
-    holder_rewards_address: &Pubkey,
-    mint_address: &Pubkey,
-    owner_address: &Pubkey,
-) -> Instruction {
-    let accounts: Vec<_> = [
-        AccountMeta::new(*holder_rewards_pool_address, false),
-        AccountMeta::new_readonly(*holder_rewards_pool_token_account_address, false),
-        AccountMeta::new(*holder_rewards_address, false),
-        AccountMeta::new_readonly(*mint_address, false),
-        AccountMeta::new(*owner_address, true),
-    ]
-    .into_iter()
-    .collect();
-    let data = PaladinRewardsInstruction::HarvestRewards.pack();
-    Instruction::new_with_bytes(crate::id(), &data, accounts)
-}
-
-/// Creates a [CloseHolderRewards](enum.PaladinRewardsInstruction.html)
-/// instruction.
-pub fn close_holder_rewards(
-    holder_rewards_pool_address: &Pubkey,
-    holder_rewards_pool_token_account_address: &Pubkey,
-    holder_rewards_address: &Pubkey,
-    mint_address: &Pubkey,
-    owner_address: &Pubkey,
-) -> Instruction {
-    let accounts = vec![
-        AccountMeta::new(*holder_rewards_pool_address, false),
-        AccountMeta::new_readonly(*holder_rewards_pool_token_account_address, false),
-        AccountMeta::new(*holder_rewards_address, false),
-        AccountMeta::new_readonly(*mint_address, false),
-        AccountMeta::new(*owner_address, true),
-    ];
-    let data = PaladinRewardsInstruction::CloseHolderRewards.pack();
-    Instruction::new_with_bytes(crate::id(), &data, accounts)
-}
-
-/// Creates a [CloseHolderRewards](enum.PaladinRewardsInstruction.html)
-/// instruction.
-pub fn deposit(
-    holder_rewards_pool_address: &Pubkey,
-    holder_rewards_pool_token_account_address: &Pubkey,
-    holder_rewards_address: &Pubkey,
-    token_account_address: &Pubkey,
-    mint_address: &Pubkey,
-    owner: &Pubkey,
-    amount: u64,
-) -> Instruction {
-    let accounts = vec![
-        AccountMeta::new(*holder_rewards_pool_address, false),
-        AccountMeta::new(*holder_rewards_pool_token_account_address, false),
-        AccountMeta::new(*holder_rewards_address, false),
-        AccountMeta::new(*token_account_address, false),
-        AccountMeta::new_readonly(*mint_address, false),
-        AccountMeta::new(*owner, true),
-        AccountMeta::new_readonly(spl_token::id(), false),
-    ];
-    let data = PaladinRewardsInstruction::Deposit { amount }.pack();
-    Instruction::new_with_bytes(crate::id(), &data, accounts)
-}
-
-pub fn withdraw(
-    holder_rewards_pool_address: &Pubkey,
-    holder_rewards_pool_token_account_address: &Pubkey,
-    holder_rewards_address: &Pubkey,
-    token_account_address: &Pubkey,
-    mint_address: &Pubkey,
-    owner: &Pubkey,
-    amount: u64,
-) -> Instruction {
-    let accounts = vec![
-        AccountMeta::new(*holder_rewards_pool_address, false),
-        AccountMeta::new(*holder_rewards_pool_token_account_address, false),
-        AccountMeta::new(*holder_rewards_address, false),
-        AccountMeta::new(*token_account_address, false),
-        AccountMeta::new_readonly(*mint_address, false),
-        AccountMeta::new(*owner, true),
-        AccountMeta::new(spl_token::id(), false),
-    ];
-    let data = PaladinRewardsInstruction::Withdraw { amount }.pack();
-    Instruction::new_with_bytes(crate::id(), &data, accounts)
 }
 
 #[cfg(test)]

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -186,6 +186,7 @@ pub enum PaladinRewardsInstruction {
     )]
     #[account(
         1,
+        writable,
         name = "holder_rewards_pool_token_account",
         desc = "Holder rewards pool token account."
     )]

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -423,8 +423,7 @@ fn process_initialize_holder_rewards(
         assert_rent_exempt(holder_rewards_info);
 
         // Write the data.
-        let mut data: std::cell::RefMut<'_, &mut [u8]> =
-            holder_rewards_info.try_borrow_mut_data()?;
+        let mut data = holder_rewards_info.try_borrow_mut_data()?;
         *bytemuck::try_from_bytes_mut(&mut data).map_err(|_| ProgramError::InvalidAccountData)? =
             HolderRewards {
                 last_accumulated_rewards_per_token: pool_state.accumulated_rewards_per_token,

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -707,19 +707,19 @@ fn process_withdraw(program_id: &Pubkey, accounts: &[AccountInfo], amount: u64) 
     // Validate that we have enough deposited tokens to withdraw
     let pool_balance =
         get_token_account_balance_checked(mint_info.key, holder_rewards_pool_token_account_info)?;
-    if holder_rewards_state.deposited == 0 {
-        return Err(PaladinRewardsError::NoDepositedTokensToWithdraw.into());
-    } else if holder_rewards_state.deposited > pool_balance {
-        return Err(PaladinRewardsError::WithdrawExceedsPoolBalance.into());
-    } else if amount > holder_rewards_state.deposited {
-        return Err(PaladinRewardsError::WithdrawExceedsDeposited.into());
-    }
-
-    let to_withdraw = if amount == 0 {
+    let to_withdraw = if amount == u64::MAX {
         holder_rewards_state.deposited
     } else {
         amount
     };
+
+    if holder_rewards_state.deposited == 0 {
+        return Err(PaladinRewardsError::NoDepositedTokensToWithdraw.into());
+    } else if holder_rewards_state.deposited > pool_balance {
+        return Err(PaladinRewardsError::WithdrawExceedsPoolBalance.into());
+    } else if to_withdraw > holder_rewards_state.deposited {
+        return Err(PaladinRewardsError::WithdrawExceedsDeposited.into());
+    }
 
     // Handle any lamports received since last harvest.
     update_accumulated_rewards_per_token(

--- a/program/tests/close_holder_rewards.rs
+++ b/program/tests/close_holder_rewards.rs
@@ -14,10 +14,10 @@ use {
     },
     paladin_rewards_program::{
         error::PaladinRewardsError,
-        instruction::close_holder_rewards,
         processor::REWARDS_PER_TOKEN_SCALING_FACTOR,
         state::{get_holder_rewards_address, get_holder_rewards_pool_address, HolderRewards},
     },
+    paladin_rewards_program_client::instructions::CloseHolderRewardsBuilder,
     setup::setup,
     solana_program_test::*,
     solana_sdk::{
@@ -66,13 +66,13 @@ async fn fail_pending_rewards() {
     )
     .await;
 
-    let instruction = close_holder_rewards(
-        &holder_rewards_pool,
-        &pool_token,
-        &holder_rewards,
-        &mint,
-        &owner.pubkey(),
-    );
+    let instruction = CloseHolderRewardsBuilder::new()
+        .holder_rewards_pool(holder_rewards_pool)
+        .holder_rewards_pool_token_account(pool_token)
+        .holder_rewards(holder_rewards)
+        .mint(mint)
+        .owner(owner.pubkey())
+        .instruction();
     let err = execute_with_payer_err(&mut context, instruction, Some(&owner)).await;
 
     assert_eq!(
@@ -123,13 +123,13 @@ async fn fail_tokens_still_deposited() {
     )
     .await;
 
-    let instruction = close_holder_rewards(
-        &holder_rewards_pool,
-        &pool_token,
-        &holder_rewards,
-        &mint,
-        &owner.pubkey(),
-    );
+    let instruction = CloseHolderRewardsBuilder::new()
+        .holder_rewards_pool(holder_rewards_pool)
+        .holder_rewards_pool_token_account(pool_token)
+        .holder_rewards(holder_rewards)
+        .mint(mint)
+        .owner(owner.pubkey())
+        .instruction();
     let err = execute_with_payer_err(&mut context, instruction, Some(&owner)).await;
 
     assert_eq!(
@@ -180,13 +180,13 @@ async fn success() {
     )
     .await;
 
-    let instruction = close_holder_rewards(
-        &holder_rewards_pool,
-        &pool_token,
-        &holder_rewards,
-        &mint,
-        &owner.pubkey(),
-    );
+    let instruction = CloseHolderRewardsBuilder::new()
+        .holder_rewards_pool(holder_rewards_pool)
+        .holder_rewards_pool_token_account(pool_token)
+        .holder_rewards(holder_rewards)
+        .mint(mint)
+        .owner(owner.pubkey())
+        .instruction();
     execute_with_payer(&mut context, instruction, Some(&owner)).await;
 
     // Assert that the owner got the rent lamprots

--- a/program/tests/deposit.rs
+++ b/program/tests/deposit.rs
@@ -14,13 +14,13 @@ use {
     },
     paladin_rewards_program::{
         error::PaladinRewardsError,
-        instruction::deposit,
         processor::REWARDS_PER_TOKEN_SCALING_FACTOR,
         state::{
             get_holder_rewards_address, get_holder_rewards_pool_address, HolderRewards,
             HolderRewardsPool,
         },
     },
+    paladin_rewards_program_client::instructions::DepositBuilder,
     setup::setup,
     solana_program_test::*,
     solana_sdk::{
@@ -70,16 +70,15 @@ async fn fail_pool_doesnt_have_enough_rewards() {
     )
     .await;
 
-    let instruction = deposit(
-        &holder_rewards_pool,
-        &pool_token,
-        &holder_rewards,
-        &owner_token,
-        &mint,
-        &owner.pubkey(),
-        DEPOSIT_AMOUNT,
-    );
-
+    let instruction = DepositBuilder::new()
+        .holder_rewards_pool(holder_rewards_pool)
+        .holder_rewards_pool_token_account(pool_token)
+        .holder_rewards(holder_rewards)
+        .token_account(owner_token)
+        .mint(mint)
+        .owner(owner.pubkey())
+        .amount(DEPOSIT_AMOUNT)
+        .instruction();
     let err = execute_with_payer_err(&mut context, instruction, Some(&owner)).await;
 
     assert_eq!(
@@ -130,16 +129,15 @@ async fn fail_not_enough_tokens_to_deposit() {
     )
     .await;
 
-    let instruction = deposit(
-        &holder_rewards_pool,
-        &pool_token,
-        &holder_rewards,
-        &owner_token,
-        &mint,
-        &owner.pubkey(),
-        INITIAL_OWNER_BALANCE,
-    );
-
+    let instruction = DepositBuilder::new()
+        .holder_rewards_pool(holder_rewards_pool)
+        .holder_rewards_pool_token_account(pool_token)
+        .holder_rewards(holder_rewards)
+        .token_account(owner_token)
+        .mint(mint)
+        .owner(owner.pubkey())
+        .amount(INITIAL_OWNER_BALANCE)
+        .instruction();
     let err = execute_with_payer_err(&mut context, instruction, Some(&owner)).await;
 
     assert_eq!(
@@ -190,15 +188,15 @@ async fn success() {
     )
     .await;
 
-    let instruction = deposit(
-        &holder_rewards_pool,
-        &pool_token,
-        &holder_rewards,
-        &owner_token,
-        &mint,
-        &owner.pubkey(),
-        DEPOSIT_AMOUNT,
-    );
+    let instruction = DepositBuilder::new()
+        .holder_rewards_pool(holder_rewards_pool)
+        .holder_rewards_pool_token_account(pool_token)
+        .holder_rewards(holder_rewards)
+        .token_account(owner_token)
+        .mint(mint)
+        .owner(owner.pubkey())
+        .amount(DEPOSIT_AMOUNT)
+        .instruction();
     execute_with_payer(&mut context, instruction, Some(&owner)).await;
 
     // Assert pool balance is DEPOSIT_AMOUNT.
@@ -259,15 +257,15 @@ async fn success() {
     assert_eq!(check_pool_lamports, previous_pool_lamports + rewards_amount);
 
     // Deposit again to check if rewards are being sent
-    let instruction = deposit(
-        &holder_rewards_pool,
-        &pool_token,
-        &holder_rewards,
-        &owner_token,
-        &mint,
-        &owner.pubkey(),
-        DEPOSIT_AMOUNT / 2,
-    );
+    let instruction = DepositBuilder::new()
+        .holder_rewards_pool(holder_rewards_pool)
+        .holder_rewards_pool_token_account(pool_token)
+        .holder_rewards(holder_rewards)
+        .token_account(owner_token)
+        .mint(mint)
+        .owner(owner.pubkey())
+        .amount(DEPOSIT_AMOUNT / 2)
+        .instruction();
     execute_with_payer(&mut context, instruction, Some(&owner)).await;
 
     // Assert pool balance is DEPOSIT_AMOUNT * 2.

--- a/program/tests/e2e.rs
+++ b/program/tests/e2e.rs
@@ -93,7 +93,7 @@ async fn validate_state(
     {
         let pool_address = get_holder_rewards_pool_address(mint, &paladin_rewards_program::id());
         let pool_account = get_account(context, &pool_address).await;
-        let pool_token = get_associated_token_address(&pool_address, &mint);
+        let pool_token = get_associated_token_address(&pool_address, mint);
         let pool_token_account = get_account(context, &pool_token).await;
         let pool_token_state = TokenAccount::unpack(&pool_token_account.data).unwrap();
         assert_eq!(pool_token_state.amount, pool.total_deposited);
@@ -871,7 +871,7 @@ async fn test_e2e() {
                 Holder {
                     last_accumulated_rewards_per_token: REWARDS_PER_TOKEN_SCALING_FACTOR * 5,
                     deposited: 100,
-                    expected_lamports: 0 + 300,
+                    expected_lamports: 300,
                 },
             ),
         ],

--- a/program/tests/e2e.rs
+++ b/program/tests/e2e.rs
@@ -528,7 +528,7 @@ async fn test_e2e() {
         .token_account(alice_token)
         .mint(mint)
         .owner(alice.pubkey())
-        .amount(0)
+        .amount(u64::MAX)
         .instruction();
     execute_with_payer(&mut context, instruction, Some(&alice)).await;
 
@@ -656,7 +656,7 @@ async fn test_e2e() {
         .token_account(bob_token)
         .mint(mint)
         .owner(bob.pubkey())
-        .amount(0)
+        .amount(u64::MAX)
         .instruction();
     execute_with_payer(&mut context, instruction, Some(&bob)).await;
 
@@ -773,7 +773,7 @@ async fn test_e2e() {
         .token_account(alice_token)
         .mint(mint)
         .owner(alice.pubkey())
-        .amount(0)
+        .amount(u64::MAX)
         .instruction();
     execute_with_payer(&mut context, instruction, Some(&alice)).await;
 
@@ -795,7 +795,7 @@ async fn test_e2e() {
         .token_account(carol_token)
         .mint(mint)
         .owner(carol.pubkey())
-        .amount(0)
+        .amount(u64::MAX)
         .instruction();
     execute_with_payer(&mut context, instruction, Some(&carol)).await;
 
@@ -910,7 +910,7 @@ async fn test_e2e() {
         .token_account(bob_token)
         .mint(mint)
         .owner(bob.pubkey())
-        .amount(0)
+        .amount(u64::MAX)
         .instruction();
     execute_with_payer(&mut context, instruction, Some(&bob)).await;
 

--- a/program/tests/e2e.rs
+++ b/program/tests/e2e.rs
@@ -16,12 +16,14 @@ use {
         },
     },
     paladin_rewards_program::{
-        instruction::{close_holder_rewards, deposit, harvest_rewards, withdraw},
         processor::REWARDS_PER_TOKEN_SCALING_FACTOR,
         state::{
             get_holder_rewards_address, get_holder_rewards_pool_address, HolderRewards,
             HolderRewardsPool,
         },
+    },
+    paladin_rewards_program_client::instructions::{
+        CloseHolderRewardsBuilder, DepositBuilder, HarvestRewardsBuilder, WithdrawBuilder,
     },
     setup::{setup, setup_mint},
     solana_program_test::*,
@@ -293,27 +295,27 @@ async fn test_e2e() {
     context.warp_forward_force_reward_interval_end().unwrap();
 
     // Alice deposits 100 tokens
-    let instruction = deposit(
-        &holder_rewards_pool,
-        &pool_token,
-        &alice_holder_rewards,
-        &alice_token,
-        &mint,
-        &alice.pubkey(),
-        100,
-    );
+    let instruction = DepositBuilder::new()
+        .holder_rewards_pool(holder_rewards_pool)
+        .holder_rewards_pool_token_account(pool_token)
+        .holder_rewards(alice_holder_rewards)
+        .token_account(alice_token)
+        .mint(mint)
+        .owner(alice.pubkey())
+        .amount(100)
+        .instruction();
     execute_with_payer(&mut context, instruction, Some(&alice)).await;
 
     // Bob deposits 50 tokens
-    let instruction = deposit(
-        &holder_rewards_pool,
-        &pool_token,
-        &bob_holder_rewards,
-        &bob_token,
-        &mint,
-        &bob.pubkey(),
-        50,
-    );
+    let instruction = DepositBuilder::new()
+        .holder_rewards_pool(holder_rewards_pool)
+        .holder_rewards_pool_token_account(pool_token)
+        .holder_rewards(bob_holder_rewards)
+        .token_account(bob_token)
+        .mint(mint)
+        .owner(bob.pubkey())
+        .amount(50)
+        .instruction();
     execute_with_payer(&mut context, instruction, Some(&bob)).await;
 
     // Validate counting is correct
@@ -351,23 +353,23 @@ async fn test_e2e() {
     send_rewards_to_pool(&mut context, &holder_rewards_pool, 150).await;
 
     // Alice harvest rewards
-    let instruction = harvest_rewards(
-        &holder_rewards_pool,
-        &pool_token,
-        &alice_holder_rewards,
-        &mint,
-        &alice.pubkey(),
-    );
+    let instruction = HarvestRewardsBuilder::new()
+        .holder_rewards_pool(holder_rewards_pool)
+        .holder_rewards_pool_token_account(pool_token)
+        .holder_rewards(alice_holder_rewards)
+        .mint(mint)
+        .owner(alice.pubkey())
+        .instruction();
     execute_with_payer(&mut context, instruction, Some(&alice)).await;
 
     // Bob harvest rewards
-    let instruction = harvest_rewards(
-        &holder_rewards_pool,
-        &pool_token,
-        &bob_holder_rewards,
-        &mint,
-        &bob.pubkey(),
-    );
+    let instruction = HarvestRewardsBuilder::new()
+        .holder_rewards_pool(holder_rewards_pool)
+        .holder_rewards_pool_token_account(pool_token)
+        .holder_rewards(bob_holder_rewards)
+        .mint(mint)
+        .owner(bob.pubkey())
+        .instruction();
     execute_with_payer(&mut context, instruction, Some(&bob)).await;
 
     // Validate with rewards
@@ -421,38 +423,38 @@ async fn test_e2e() {
     context.warp_forward_force_reward_interval_end().unwrap();
 
     // Carol deposits 150 tokens
-    let instruction = deposit(
-        &holder_rewards_pool,
-        &pool_token,
-        &carol_holder_rewards,
-        &carol_token,
-        &mint,
-        &carol.pubkey(),
-        150,
-    );
+    let instruction = DepositBuilder::new()
+        .holder_rewards_pool(holder_rewards_pool)
+        .holder_rewards_pool_token_account(pool_token)
+        .holder_rewards(carol_holder_rewards)
+        .token_account(carol_token)
+        .mint(mint)
+        .owner(carol.pubkey())
+        .amount(150)
+        .instruction();
     execute_with_payer(&mut context, instruction, Some(&carol)).await;
 
     // Send 300 rewards
     send_rewards_to_pool(&mut context, &holder_rewards_pool, 300).await;
 
     // Alice harvest rewards
-    let instruction = harvest_rewards(
-        &holder_rewards_pool,
-        &pool_token,
-        &alice_holder_rewards,
-        &mint,
-        &alice.pubkey(),
-    );
+    let instruction = HarvestRewardsBuilder::new()
+        .holder_rewards_pool(holder_rewards_pool)
+        .holder_rewards_pool_token_account(pool_token)
+        .holder_rewards(alice_holder_rewards)
+        .mint(mint)
+        .owner(alice.pubkey())
+        .instruction();
     execute_with_payer(&mut context, instruction, Some(&alice)).await;
 
     // Carol harvest rewards
-    let instruction = harvest_rewards(
-        &holder_rewards_pool,
-        &pool_token,
-        &carol_holder_rewards,
-        &mint,
-        &carol.pubkey(),
-    );
+    let instruction = HarvestRewardsBuilder::new()
+        .holder_rewards_pool(holder_rewards_pool)
+        .holder_rewards_pool_token_account(pool_token)
+        .holder_rewards(carol_holder_rewards)
+        .mint(mint)
+        .owner(carol.pubkey())
+        .instruction();
     execute_with_payer(&mut context, instruction, Some(&carol)).await;
 
     // Validate with rewards
@@ -519,50 +521,50 @@ async fn test_e2e() {
     context.warp_forward_force_reward_interval_end().unwrap();
 
     // Alice withdraws tokens
-    let instruction = withdraw(
-        &holder_rewards_pool,
-        &pool_token,
-        &alice_holder_rewards,
-        &alice_token,
-        &mint,
-        &alice.pubkey(),
-        0,
-    );
+    let instruction = WithdrawBuilder::new()
+        .holder_rewards_pool(holder_rewards_pool)
+        .holder_rewards_pool_token_account(pool_token)
+        .holder_rewards(alice_holder_rewards)
+        .token_account(alice_token)
+        .mint(mint)
+        .owner(alice.pubkey())
+        .amount(0)
+        .instruction();
     execute_with_payer(&mut context, instruction, Some(&alice)).await;
 
     // Dave deposits
-    let instruction = deposit(
-        &holder_rewards_pool,
-        &pool_token,
-        &dave_holder_rewards,
-        &dave_token,
-        &mint,
-        &dave.pubkey(),
-        100,
-    );
+    let instruction = DepositBuilder::new()
+        .holder_rewards_pool(holder_rewards_pool)
+        .holder_rewards_pool_token_account(pool_token)
+        .holder_rewards(dave_holder_rewards)
+        .token_account(dave_token)
+        .mint(mint)
+        .owner(dave.pubkey())
+        .amount(100)
+        .instruction();
     execute_with_payer(&mut context, instruction, Some(&dave)).await;
 
     // Send 300 rewards
     send_rewards_to_pool(&mut context, &holder_rewards_pool, 300).await;
 
     // Bob harvest rewards
-    let instruction = harvest_rewards(
-        &holder_rewards_pool,
-        &pool_token,
-        &bob_holder_rewards,
-        &mint,
-        &bob.pubkey(),
-    );
+    let instruction = HarvestRewardsBuilder::new()
+        .holder_rewards_pool(holder_rewards_pool)
+        .holder_rewards_pool_token_account(pool_token)
+        .holder_rewards(bob_holder_rewards)
+        .mint(mint)
+        .owner(bob.pubkey())
+        .instruction();
     execute_with_payer(&mut context, instruction, Some(&bob)).await;
 
     // Carol harvest rewards
-    let instruction = harvest_rewards(
-        &holder_rewards_pool,
-        &pool_token,
-        &carol_holder_rewards,
-        &mint,
-        &carol.pubkey(),
-    );
+    let instruction = HarvestRewardsBuilder::new()
+        .holder_rewards_pool(holder_rewards_pool)
+        .holder_rewards_pool_token_account(pool_token)
+        .holder_rewards(carol_holder_rewards)
+        .mint(mint)
+        .owner(carol.pubkey())
+        .instruction();
     execute_with_payer(&mut context, instruction, Some(&carol)).await;
 
     validate_state(
@@ -635,72 +637,72 @@ async fn test_e2e() {
     context.warp_forward_force_reward_interval_end().unwrap();
 
     // Alice deposits
-    let instruction = deposit(
-        &holder_rewards_pool,
-        &pool_token,
-        &alice_holder_rewards,
-        &alice_token,
-        &mint,
-        &alice.pubkey(),
-        100,
-    );
+    let instruction = DepositBuilder::new()
+        .holder_rewards_pool(holder_rewards_pool)
+        .holder_rewards_pool_token_account(pool_token)
+        .holder_rewards(alice_holder_rewards)
+        .token_account(alice_token)
+        .mint(mint)
+        .owner(alice.pubkey())
+        .amount(100)
+        .instruction();
     execute_with_payer(&mut context, instruction, Some(&alice)).await;
 
     // Bob withdraws tokens
-    let instruction = withdraw(
-        &holder_rewards_pool,
-        &pool_token,
-        &bob_holder_rewards,
-        &bob_token,
-        &mint,
-        &bob.pubkey(),
-        0,
-    );
+    let instruction = WithdrawBuilder::new()
+        .holder_rewards_pool(holder_rewards_pool)
+        .holder_rewards_pool_token_account(pool_token)
+        .holder_rewards(bob_holder_rewards)
+        .token_account(bob_token)
+        .mint(mint)
+        .owner(bob.pubkey())
+        .amount(0)
+        .instruction();
     execute_with_payer(&mut context, instruction, Some(&bob)).await;
 
     // Bob closes account
-    let instruction = close_holder_rewards(
-        &holder_rewards_pool,
-        &pool_token,
-        &bob_holder_rewards,
-        &mint,
-        &bob.pubkey(),
-    );
+    let instruction = CloseHolderRewardsBuilder::new()
+        .holder_rewards_pool(holder_rewards_pool)
+        .holder_rewards_pool_token_account(pool_token)
+        .holder_rewards(bob_holder_rewards)
+        .mint(mint)
+        .owner(bob.pubkey())
+        .instruction();
     execute_with_payer(&mut context, instruction, Some(&bob)).await;
 
     // Carol deposits
-    let instruction = deposit(
-        &holder_rewards_pool,
-        &pool_token,
-        &carol_holder_rewards,
-        &carol_token,
-        &mint,
-        &carol.pubkey(),
-        150,
-    );
+    let instruction = DepositBuilder::new()
+        .holder_rewards_pool(holder_rewards_pool)
+        .holder_rewards_pool_token_account(pool_token)
+        .holder_rewards(carol_holder_rewards)
+        .token_account(carol_token)
+        .mint(mint)
+        .owner(carol.pubkey())
+        .amount(150)
+        .instruction();
     execute_with_payer(&mut context, instruction, Some(&carol)).await;
 
     // Send 500 rewards
     send_rewards_to_pool(&mut context, &holder_rewards_pool, 500).await;
 
     // Alice harvest rewards
-    let instruction = harvest_rewards(
-        &holder_rewards_pool,
-        &pool_token,
-        &alice_holder_rewards,
-        &mint,
-        &alice.pubkey(),
-    );
+    let instruction = HarvestRewardsBuilder::new()
+        .holder_rewards_pool(holder_rewards_pool)
+        .holder_rewards_pool_token_account(pool_token)
+        .holder_rewards(alice_holder_rewards)
+        .mint(mint)
+        .owner(alice.pubkey())
+        .instruction();
     execute_with_payer(&mut context, instruction, Some(&alice)).await;
 
     // Carol harvest rewards
-    let instruction = harvest_rewards(
-        &holder_rewards_pool,
-        &pool_token,
-        &carol_holder_rewards,
-        &mint,
-        &carol.pubkey(),
-    );
+    let instruction = HarvestRewardsBuilder::new()
+        .holder_rewards_pool(holder_rewards_pool)
+        .holder_rewards_pool_token_account(pool_token)
+        .holder_rewards(carol_holder_rewards)
+        .mint(mint)
+        .owner(carol.pubkey())
+        .instruction();
     execute_with_payer(&mut context, instruction, Some(&carol)).await;
 
     validate_state(
@@ -764,85 +766,85 @@ async fn test_e2e() {
     context.warp_forward_force_reward_interval_end().unwrap();
 
     // Alice withdraws tokens
-    let instruction = withdraw(
-        &holder_rewards_pool,
-        &pool_token,
-        &alice_holder_rewards,
-        &alice_token,
-        &mint,
-        &alice.pubkey(),
-        0,
-    );
+    let instruction = WithdrawBuilder::new()
+        .holder_rewards_pool(holder_rewards_pool)
+        .holder_rewards_pool_token_account(pool_token)
+        .holder_rewards(alice_holder_rewards)
+        .token_account(alice_token)
+        .mint(mint)
+        .owner(alice.pubkey())
+        .amount(0)
+        .instruction();
     execute_with_payer(&mut context, instruction, Some(&alice)).await;
 
     // Alice closes account
-    let instruction = close_holder_rewards(
-        &holder_rewards_pool,
-        &pool_token,
-        &alice_holder_rewards,
-        &mint,
-        &alice.pubkey(),
-    );
+    let instruction = CloseHolderRewardsBuilder::new()
+        .holder_rewards_pool(holder_rewards_pool)
+        .holder_rewards_pool_token_account(pool_token)
+        .holder_rewards(alice_holder_rewards)
+        .mint(mint)
+        .owner(alice.pubkey())
+        .instruction();
     execute_with_payer(&mut context, instruction, Some(&alice)).await;
 
     // Carol withdraws tokens
-    let instruction = withdraw(
-        &holder_rewards_pool,
-        &pool_token,
-        &carol_holder_rewards,
-        &carol_token,
-        &mint,
-        &carol.pubkey(),
-        0,
-    );
+    let instruction = WithdrawBuilder::new()
+        .holder_rewards_pool(holder_rewards_pool)
+        .holder_rewards_pool_token_account(pool_token)
+        .holder_rewards(carol_holder_rewards)
+        .token_account(carol_token)
+        .mint(mint)
+        .owner(carol.pubkey())
+        .amount(0)
+        .instruction();
     execute_with_payer(&mut context, instruction, Some(&carol)).await;
 
     // Carol closes account
-    let instruction = close_holder_rewards(
-        &holder_rewards_pool,
-        &pool_token,
-        &carol_holder_rewards,
-        &mint,
-        &carol.pubkey(),
-    );
+    let instruction = CloseHolderRewardsBuilder::new()
+        .holder_rewards_pool(holder_rewards_pool)
+        .holder_rewards_pool_token_account(pool_token)
+        .holder_rewards(carol_holder_rewards)
+        .mint(mint)
+        .owner(carol.pubkey())
+        .instruction();
     execute_with_payer(&mut context, instruction, Some(&carol)).await;
 
     // Bob creates new holder account
     setup_holder_rewards_account(&mut context, &bob_holder_rewards, 0, 0).await;
 
     // Bob deposits
-    let instruction = deposit(
-        &holder_rewards_pool,
-        &pool_token,
-        &bob_holder_rewards,
-        &bob_token,
-        &mint,
-        &bob.pubkey(),
-        100,
-    );
+    let instruction = DepositBuilder::new()
+        .holder_rewards_pool(holder_rewards_pool)
+        .holder_rewards_pool_token_account(pool_token)
+        .holder_rewards(bob_holder_rewards)
+        .token_account(bob_token)
+        .mint(mint)
+        .owner(bob.pubkey())
+        .amount(100)
+        .instruction();
     execute_with_payer(&mut context, instruction, Some(&bob)).await;
 
     // Send 200 rewards
     send_rewards_to_pool(&mut context, &holder_rewards_pool, 200).await;
 
     // Bob harvest rewards
-    let instruction = harvest_rewards(
-        &holder_rewards_pool,
-        &pool_token,
-        &bob_holder_rewards,
-        &mint,
-        &bob.pubkey(),
-    );
+    let instruction = HarvestRewardsBuilder::new()
+        .holder_rewards_pool(holder_rewards_pool)
+        .holder_rewards_pool_token_account(pool_token)
+        .holder_rewards(bob_holder_rewards)
+        .mint(mint)
+        .owner(bob.pubkey())
+        .instruction();
     execute_with_payer(&mut context, instruction, Some(&bob)).await;
 
     // Dave harvest rewards
-    let instruction = harvest_rewards(
-        &holder_rewards_pool,
-        &pool_token,
-        &dave_holder_rewards,
-        &mint,
-        &dave.pubkey(),
-    );
+    let instruction = HarvestRewardsBuilder::new()
+        .holder_rewards_pool(holder_rewards_pool)
+        .holder_rewards_pool_token_account(pool_token)
+        .holder_rewards(dave_holder_rewards)
+        .mint(mint)
+        .owner(dave.pubkey())
+        .instruction();
     execute_with_payer(&mut context, instruction, Some(&dave)).await;
 
     let holder_rent_exempt_lamports = holder_rent_exempt_lamports(&mut context).await;
@@ -901,37 +903,37 @@ async fn test_e2e() {
     send_rewards_to_pool(&mut context, &holder_rewards_pool, 200).await;
 
     // Bob withdraws tokens
-    let instruction = withdraw(
-        &holder_rewards_pool,
-        &pool_token,
-        &bob_holder_rewards,
-        &bob_token,
-        &mint,
-        &bob.pubkey(),
-        0,
-    );
+    let instruction = WithdrawBuilder::new()
+        .holder_rewards_pool(holder_rewards_pool)
+        .holder_rewards_pool_token_account(pool_token)
+        .holder_rewards(bob_holder_rewards)
+        .token_account(bob_token)
+        .mint(mint)
+        .owner(bob.pubkey())
+        .amount(0)
+        .instruction();
     execute_with_payer(&mut context, instruction, Some(&bob)).await;
 
     // Bob closes account
-    let instruction = close_holder_rewards(
-        &holder_rewards_pool,
-        &pool_token,
-        &bob_holder_rewards,
-        &mint,
-        &bob.pubkey(),
-    );
+    let instruction = CloseHolderRewardsBuilder::new()
+        .holder_rewards_pool(holder_rewards_pool)
+        .holder_rewards_pool_token_account(pool_token)
+        .holder_rewards(bob_holder_rewards)
+        .mint(mint)
+        .owner(bob.pubkey())
+        .instruction();
     execute_with_payer(&mut context, instruction, Some(&bob)).await;
 
     // Dave withdraws tokens
-    let instruction = withdraw(
-        &holder_rewards_pool,
-        &pool_token,
-        &dave_holder_rewards,
-        &dave_token,
-        &mint,
-        &dave.pubkey(),
-        50,
-    );
+    let instruction = WithdrawBuilder::new()
+        .holder_rewards_pool(holder_rewards_pool)
+        .holder_rewards_pool_token_account(pool_token)
+        .holder_rewards(dave_holder_rewards)
+        .token_account(dave_token)
+        .mint(mint)
+        .owner(dave.pubkey())
+        .amount(50)
+        .instruction();
     execute_with_payer(&mut context, instruction, Some(&dave)).await;
 
     validate_state(

--- a/program/tests/harvest_rewards.rs
+++ b/program/tests/harvest_rewards.rs
@@ -13,10 +13,10 @@ use {
     },
     paladin_rewards_program::{
         error::PaladinRewardsError,
-        instruction::harvest_rewards,
         processor::REWARDS_PER_TOKEN_SCALING_FACTOR,
         state::{get_holder_rewards_address, get_holder_rewards_pool_address, HolderRewards},
     },
+    paladin_rewards_program_client::instructions::HarvestRewardsBuilder,
     setup::setup,
     solana_program_test::*,
     solana_sdk::{
@@ -69,13 +69,13 @@ async fn fail_not_enough_lamports() {
     )
     .await;
 
-    let instruction = harvest_rewards(
-        &holder_rewards_pool,
-        &pool_token,
-        &holder_rewards,
-        &mint,
-        &owner.pubkey(),
-    );
+    let instruction = HarvestRewardsBuilder::new()
+        .holder_rewards_pool(holder_rewards_pool)
+        .holder_rewards_pool_token_account(pool_token)
+        .holder_rewards(holder_rewards)
+        .mint(mint)
+        .owner(owner.pubkey())
+        .instruction();
 
     let err = execute_with_payer_err(&mut context, instruction, Some(&owner)).await;
 
@@ -262,13 +262,13 @@ async fn success(pool: Pool, holder: Holder, expected_harvested_rewards: u64) {
         .lamports;
     let owner_beginning_lamports: u64 = 0;
 
-    let instruction = harvest_rewards(
-        &holder_rewards_pool,
-        &pool_token,
-        &holder_rewards,
-        &mint,
-        &owner.pubkey(),
-    );
+    let instruction = HarvestRewardsBuilder::new()
+        .holder_rewards_pool(holder_rewards_pool)
+        .holder_rewards_pool_token_account(pool_token)
+        .holder_rewards(holder_rewards)
+        .mint(mint)
+        .owner(owner.pubkey())
+        .instruction();
 
     let transaction = Transaction::new_signed_with_payer(
         &[instruction],

--- a/program/tests/initialize_holder_rewards.rs
+++ b/program/tests/initialize_holder_rewards.rs
@@ -7,12 +7,12 @@ use {
     crate::execute_utils::{execute_with_payer, execute_with_payer_err},
     paladin_rewards_program::{
         error::PaladinRewardsError,
-        instruction::initialize_holder_rewards,
         state::{
             get_holder_rewards_address, get_holder_rewards_pool_address, HolderRewards,
             HolderRewardsPool,
         },
     },
+    paladin_rewards_program_client::instructions::InitializeHolderRewardsBuilder,
     setup::{setup, setup_holder_rewards_pool_account, setup_mint, setup_token_account},
     solana_program_test::*,
     solana_sdk::{
@@ -59,13 +59,13 @@ async fn fail_holder_rewards_pool_incorrect_owner() {
         );
     }
 
-    let instruction = initialize_holder_rewards(
-        &holder_rewards_pool,
-        &pool_token_account,
-        &holder_rewards,
-        &owner.pubkey(),
-        &mint,
-    );
+    let instruction = InitializeHolderRewardsBuilder::new()
+        .holder_rewards_pool(holder_rewards_pool)
+        .holder_rewards_pool_token_account(pool_token_account)
+        .holder_rewards(holder_rewards)
+        .owner(owner.pubkey())
+        .mint(mint)
+        .instruction();
 
     let err = execute_with_payer_err(&mut context, instruction, Some(&owner)).await;
 
@@ -99,13 +99,13 @@ async fn fail_holder_rewards_pool_incorrect_address() {
     .await;
     setup_mint(&mut context, &mint, 0, None).await;
 
-    let instruction = initialize_holder_rewards(
-        &holder_rewards_pool,
-        &pool_token_account,
-        &holder_rewards,
-        &owner.pubkey(),
-        &mint,
-    );
+    let instruction = InitializeHolderRewardsBuilder::new()
+        .holder_rewards_pool(holder_rewards_pool)
+        .holder_rewards_pool_token_account(pool_token_account)
+        .holder_rewards(holder_rewards)
+        .owner(owner.pubkey())
+        .mint(mint)
+        .instruction();
 
     let err = execute_with_payer_err(&mut context, instruction, Some(&owner)).await;
 
@@ -137,13 +137,13 @@ async fn fail_holder_rewards_pool_token_incorrect_address() {
     setup_token_account(&mut context, &pool_token_account, &rand, &mint, 0).await;
     setup_mint(&mut context, &mint, 0, None).await;
 
-    let instruction = initialize_holder_rewards(
-        &holder_rewards_pool,
-        &pool_token_account,
-        &holder_rewards,
-        &owner.pubkey(),
-        &mint,
-    );
+    let instruction = InitializeHolderRewardsBuilder::new()
+        .holder_rewards_pool(holder_rewards_pool)
+        .holder_rewards_pool_token_account(pool_token_account)
+        .holder_rewards(holder_rewards)
+        .owner(owner.pubkey())
+        .mint(mint)
+        .instruction();
 
     let err = execute_with_payer_err(&mut context, instruction, Some(&owner)).await;
 
@@ -193,13 +193,13 @@ async fn fail_holder_rewards_pool_invalid_data() {
         );
     }
 
-    let instruction = initialize_holder_rewards(
-        &holder_rewards_pool,
-        &pool_token_account,
-        &holder_rewards,
-        &owner.pubkey(),
-        &mint,
-    );
+    let instruction = InitializeHolderRewardsBuilder::new()
+        .holder_rewards_pool(holder_rewards_pool)
+        .holder_rewards_pool_token_account(pool_token_account)
+        .holder_rewards(holder_rewards)
+        .owner(owner.pubkey())
+        .mint(mint)
+        .instruction();
 
     let err = execute_with_payer_err(&mut context, instruction, Some(&owner)).await;
 
@@ -233,13 +233,13 @@ async fn fail_holder_rewards_incorrect_address() {
     setup_token_account(&mut context, &token_account, &owner.pubkey(), &mint, 0).await;
     setup_mint(&mut context, &mint, 0, None).await;
 
-    let instruction = initialize_holder_rewards(
-        &holder_rewards_pool,
-        &pool_token_account,
-        &holder_rewards,
-        &owner.pubkey(),
-        &mint,
-    );
+    let instruction = InitializeHolderRewardsBuilder::new()
+        .holder_rewards_pool(holder_rewards_pool)
+        .holder_rewards_pool_token_account(pool_token_account)
+        .holder_rewards(holder_rewards)
+        .owner(owner.pubkey())
+        .mint(mint)
+        .instruction();
 
     let err = execute_with_payer_err(&mut context, instruction, Some(&owner)).await;
 
@@ -290,13 +290,13 @@ async fn fail_holder_rewards_account_initialized() {
         );
     }
 
-    let instruction = initialize_holder_rewards(
-        &holder_rewards_pool,
-        &pool_token_account,
-        &holder_rewards,
-        &owner.pubkey(),
-        &mint,
-    );
+    let instruction = InitializeHolderRewardsBuilder::new()
+        .holder_rewards_pool(holder_rewards_pool)
+        .holder_rewards_pool_token_account(pool_token_account)
+        .holder_rewards(holder_rewards)
+        .owner(owner.pubkey())
+        .mint(mint)
+        .instruction();
 
     let err = execute_with_payer_err(&mut context, instruction, Some(&owner)).await;
 
@@ -365,13 +365,13 @@ async fn success() {
         );
     }
 
-    let instruction = initialize_holder_rewards(
-        &holder_rewards_pool,
-        &pool_token_account,
-        &holder_rewards,
-        &owner.pubkey(),
-        &mint,
-    );
+    let instruction = InitializeHolderRewardsBuilder::new()
+        .holder_rewards_pool(holder_rewards_pool)
+        .holder_rewards_pool_token_account(pool_token_account)
+        .holder_rewards(holder_rewards)
+        .owner(owner.pubkey())
+        .mint(mint)
+        .instruction();
 
     execute_with_payer(&mut context, instruction, Some(&owner)).await;
 

--- a/program/tests/initialize_holder_rewards_pool.rs
+++ b/program/tests/initialize_holder_rewards_pool.rs
@@ -10,9 +10,9 @@ use {
     },
     paladin_rewards_program::{
         error::PaladinRewardsError,
-        instruction::initialize_holder_rewards_pool,
         state::{get_holder_rewards_pool_address, HolderRewardsPool},
     },
+    paladin_rewards_program_client::instructions::InitializeHolderRewardsPoolBuilder,
     setup::{setup, setup_mint},
     solana_program_test::*,
     solana_sdk::{
@@ -43,8 +43,11 @@ async fn fail_mint_invalid_data() {
         );
     }
 
-    let instruction =
-        initialize_holder_rewards_pool(&holder_rewards_pool, &pool_token_account, &mint);
+    let instruction = InitializeHolderRewardsPoolBuilder::new()
+        .holder_rewards_pool(holder_rewards_pool)
+        .holder_rewards_pool_token_account(pool_token_account)
+        .mint(mint)
+        .instruction();
 
     let err = execute_with_payer_err(&mut context, instruction, None).await;
 
@@ -72,8 +75,11 @@ async fn fail_holder_rewards_pool_incorrect_address() {
     )
     .await;
 
-    let instruction =
-        initialize_holder_rewards_pool(&holder_rewards_pool, &pool_token_account, &mint);
+    let instruction = InitializeHolderRewardsPoolBuilder::new()
+        .holder_rewards_pool(holder_rewards_pool)
+        .holder_rewards_pool_token_account(pool_token_account)
+        .mint(mint)
+        .instruction();
 
     let err = execute_with_payer_err(&mut context, instruction, None).await;
 
@@ -99,8 +105,11 @@ async fn fail_holder_rewards_pool_incorrect_token_address() {
     setup_mint(&mut context, &mint, 0, None).await;
     setup_token_account(&mut context, &pool_token_account, &rand, &mint, 0).await;
 
-    let instruction =
-        initialize_holder_rewards_pool(&holder_rewards_pool, &pool_token_account, &mint);
+    let instruction = InitializeHolderRewardsPoolBuilder::new()
+        .holder_rewards_pool(holder_rewards_pool)
+        .holder_rewards_pool_token_account(pool_token_account)
+        .mint(mint)
+        .instruction();
 
     let err = execute_with_payer_err(&mut context, instruction, None).await;
 
@@ -145,8 +154,11 @@ async fn fail_holder_rewards_pool_account_initialized() {
         );
     }
 
-    let instruction =
-        initialize_holder_rewards_pool(&holder_rewards_pool, &pool_token_account, &mint);
+    let instruction = InitializeHolderRewardsPoolBuilder::new()
+        .holder_rewards_pool(holder_rewards_pool)
+        .holder_rewards_pool_token_account(pool_token_account)
+        .mint(mint)
+        .instruction();
 
     let err = execute_with_payer_err(&mut context, instruction, None).await;
 
@@ -183,8 +195,11 @@ async fn success() {
         &AccountSharedData::new(lamports, 0, &system_program::id()),
     );
 
-    let instruction =
-        initialize_holder_rewards_pool(&holder_rewards_pool, &pool_token_account, &mint);
+    let instruction = InitializeHolderRewardsPoolBuilder::new()
+        .holder_rewards_pool(holder_rewards_pool)
+        .holder_rewards_pool_token_account(pool_token_account)
+        .mint(mint)
+        .instruction();
 
     execute_with_payer(&mut context, instruction, None).await;
 

--- a/program/tests/setup.rs
+++ b/program/tests/setup.rs
@@ -38,7 +38,7 @@ pub async fn setup_mint(
         let state = Mint {
             is_initialized: true,
             supply,
-            mint_authority: mint_authority.try_into().unwrap(),
+            mint_authority: mint_authority.into(),
             ..Mint::default()
         };
         Mint::pack(state, &mut data).unwrap();
@@ -155,7 +155,7 @@ pub async fn setup_holder_rewards_pool_account_with_token_account(
 
     setup_token_account(
         context,
-        &holder_rewards_pool_token_account_address,
+        holder_rewards_pool_token_account_address,
         holder_rewards_pool_address,
         mint,
         token_balance,

--- a/program/tests/withdraw.rs
+++ b/program/tests/withdraw.rs
@@ -14,10 +14,10 @@ use {
     },
     paladin_rewards_program::{
         error::PaladinRewardsError,
-        instruction::withdraw,
         processor::REWARDS_PER_TOKEN_SCALING_FACTOR,
         state::{get_holder_rewards_address, get_holder_rewards_pool_address},
     },
+    paladin_rewards_program_client::instructions::WithdrawBuilder,
     setup::setup,
     solana_program_test::*,
     solana_sdk::{
@@ -70,15 +70,15 @@ async fn fail_empty_pool() {
     .await;
 
     // Should fail as the user have more deposited tokens than the pool owns
-    let instruction = withdraw(
-        &holder_rewards_pool,
-        &pool_token,
-        &holder_rewards,
-        &owner_token,
-        &mint,
-        &owner.pubkey(),
-        0,
-    );
+    let instruction = WithdrawBuilder::new()
+        .holder_rewards_pool(holder_rewards_pool)
+        .holder_rewards_pool_token_account(pool_token)
+        .holder_rewards(holder_rewards)
+        .token_account(owner_token)
+        .mint(mint)
+        .owner(owner.pubkey())
+        .amount(0)
+        .instruction();
     let err = execute_with_payer_err(&mut context, instruction, Some(&owner)).await;
 
     assert_eq!(
@@ -130,15 +130,15 @@ async fn fail_no_deposited_tokens() {
     .await;
 
     // Should fail as there are no tokens deposited in the pool by this user
-    let instruction = withdraw(
-        &holder_rewards_pool,
-        &pool_token,
-        &holder_rewards,
-        &owner_token,
-        &mint,
-        &owner.pubkey(),
-        0,
-    );
+    let instruction = WithdrawBuilder::new()
+        .holder_rewards_pool(holder_rewards_pool)
+        .holder_rewards_pool_token_account(pool_token)
+        .holder_rewards(holder_rewards)
+        .token_account(owner_token)
+        .mint(mint)
+        .owner(owner.pubkey())
+        .amount(0)
+        .instruction();
     let err = execute_with_payer_err(&mut context, instruction, Some(&owner)).await;
 
     assert_eq!(
@@ -193,15 +193,15 @@ async fn success_with_rewards() {
     .await;
 
     // Do withdraw
-    let instruction = withdraw(
-        &holder_rewards_pool,
-        &pool_token,
-        &holder_rewards,
-        &owner_token,
-        &mint,
-        &owner.pubkey(),
-        DEPOSIT_AMOUNT,
-    );
+    let instruction = WithdrawBuilder::new()
+        .holder_rewards_pool(holder_rewards_pool)
+        .holder_rewards_pool_token_account(pool_token)
+        .holder_rewards(holder_rewards)
+        .token_account(owner_token)
+        .mint(mint)
+        .owner(owner.pubkey())
+        .amount(DEPOSIT_AMOUNT)
+        .instruction();
     execute_with_payer(&mut context, instruction, Some(&owner)).await;
 
     // Assert pool balance is 0 (single depositor withdrews all).
@@ -280,15 +280,15 @@ async fn success_without_rewards() {
     .await;
 
     // Do wihthdraw
-    let instruction = withdraw(
-        &holder_rewards_pool,
-        &pool_token,
-        &holder_rewards,
-        &owner_token,
-        &mint,
-        &owner.pubkey(),
-        DEPOSIT_AMOUNT,
-    );
+    let instruction = WithdrawBuilder::new()
+        .holder_rewards_pool(holder_rewards_pool)
+        .holder_rewards_pool_token_account(pool_token)
+        .holder_rewards(holder_rewards)
+        .token_account(owner_token)
+        .mint(mint)
+        .owner(owner.pubkey())
+        .amount(DEPOSIT_AMOUNT)
+        .instruction();
     execute_with_payer(&mut context, instruction, Some(&owner)).await;
 
     // Assert pool balance is 0 (single depositor withdrews all).
@@ -376,15 +376,15 @@ async fn success_withdraw_half() {
     .await;
 
     // Do withdraw
-    let instruction = withdraw(
-        &holder_rewards_pool,
-        &pool_token,
-        &holder_rewards,
-        &owner_token,
-        &mint,
-        &owner.pubkey(),
-        DEPOSIT_AMOUNT / 2,
-    );
+    let instruction = WithdrawBuilder::new()
+        .holder_rewards_pool(holder_rewards_pool)
+        .holder_rewards_pool_token_account(pool_token)
+        .holder_rewards(holder_rewards)
+        .token_account(owner_token)
+        .mint(mint)
+        .owner(owner.pubkey())
+        .amount(DEPOSIT_AMOUNT / 2)
+        .instruction();
     execute_with_payer(&mut context, instruction, Some(&owner)).await;
 
     // Assert pool balance is DEPOSIT_AMOUNT / 2 (single depositor withdrews half).

--- a/program/tests/withdraw.rs
+++ b/program/tests/withdraw.rs
@@ -26,6 +26,7 @@ use {
     },
     spl_associated_token_account::get_associated_token_address,
     spl_token::state::Account as TokenAccount,
+    std::u64,
 };
 
 pub const REWARDS_AMOUNT: u64 = 100_000_000_000_000;
@@ -77,7 +78,7 @@ async fn fail_empty_pool() {
         .token_account(owner_token)
         .mint(mint)
         .owner(owner.pubkey())
-        .amount(0)
+        .amount(u64::MAX)
         .instruction();
     let err = execute_with_payer_err(&mut context, instruction, Some(&owner)).await;
 
@@ -137,7 +138,7 @@ async fn fail_no_deposited_tokens() {
         .token_account(owner_token)
         .mint(mint)
         .owner(owner.pubkey())
-        .amount(0)
+        .amount(u64::MAX)
         .instruction();
     let err = execute_with_payer_err(&mut context, instruction, Some(&owner)).await;
 

--- a/program/tests/withdraw.rs
+++ b/program/tests/withdraw.rs
@@ -77,6 +77,7 @@ async fn fail_empty_pool() {
         &owner_token,
         &mint,
         &owner.pubkey(),
+        0,
     );
     let err = execute_with_payer_err(&mut context, instruction, Some(&owner)).await;
 
@@ -136,6 +137,7 @@ async fn fail_no_deposited_tokens() {
         &owner_token,
         &mint,
         &owner.pubkey(),
+        0,
     );
     let err = execute_with_payer_err(&mut context, instruction, Some(&owner)).await;
 
@@ -198,6 +200,7 @@ async fn success_with_rewards() {
         &owner_token,
         &mint,
         &owner.pubkey(),
+        DEPOSIT_AMOUNT,
     );
     execute_with_payer(&mut context, instruction, Some(&owner)).await;
 
@@ -284,6 +287,7 @@ async fn success_without_rewards() {
         &owner_token,
         &mint,
         &owner.pubkey(),
+        DEPOSIT_AMOUNT,
     );
     execute_with_payer(&mut context, instruction, Some(&owner)).await;
 
@@ -327,4 +331,96 @@ async fn success_without_rewards() {
         .await
         .unwrap();
     assert!(owner_account.is_none());
+}
+
+#[tokio::test]
+async fn success_withdraw_half() {
+    let owner = Keypair::new();
+    let mint = Pubkey::new_unique();
+
+    let mut context = setup().start_with_context().await;
+
+    // Setup pool
+    let holder_rewards_pool =
+        get_holder_rewards_pool_address(&mint, &paladin_rewards_program::id());
+    let pool_token = get_associated_token_address(&holder_rewards_pool, &mint);
+
+    setup_holder_rewards_pool_account_with_token_account(
+        &mut context,
+        &mint,
+        &holder_rewards_pool,
+        &pool_token,
+        0,
+        0,
+        DEPOSIT_AMOUNT,
+    )
+    .await;
+
+    // Send rewards to the pool to update rates
+    send_rewards_to_pool(&mut context, &holder_rewards_pool, REWARDS_AMOUNT).await;
+
+    // Setup token account for the owner.
+    let holder_rewards =
+        get_holder_rewards_address(&owner.pubkey(), &paladin_rewards_program::id());
+    let owner_token = get_associated_token_address(&owner.pubkey(), &mint);
+    setup_holder_rewards_account_with_token_account(
+        &mut context,
+        &mint,
+        &owner.pubkey(),
+        &holder_rewards,
+        &owner_token,
+        DEPOSIT_AMOUNT,
+        0,
+        INITIAL_OWNER_BALANCE - DEPOSIT_AMOUNT,
+    )
+    .await;
+
+    // Do withdraw
+    let instruction = withdraw(
+        &holder_rewards_pool,
+        &pool_token,
+        &holder_rewards,
+        &owner_token,
+        &mint,
+        &owner.pubkey(),
+        DEPOSIT_AMOUNT / 2,
+    );
+    execute_with_payer(&mut context, instruction, Some(&owner)).await;
+
+    // Assert pool balance is DEPOSIT_AMOUNT / 2 (single depositor withdrews half).
+    let pool_token_account = context
+        .banks_client
+        .get_account(pool_token)
+        .await
+        .unwrap()
+        .unwrap();
+    let pool_token_account_balance = TokenAccount::unpack(&pool_token_account.data)
+        .unwrap()
+        .amount;
+    assert_eq!(pool_token_account_balance, DEPOSIT_AMOUNT / 2);
+
+    // Assert owner got half the tokens back
+    let owner_token_account = context
+        .banks_client
+        .get_account(owner_token)
+        .await
+        .unwrap()
+        .unwrap();
+    let owner_token_account_balance = TokenAccount::unpack(&owner_token_account.data)
+        .unwrap()
+        .amount;
+    assert_eq!(
+        owner_token_account_balance,
+        INITIAL_OWNER_BALANCE - DEPOSIT_AMOUNT / 2
+    );
+
+    // Get owner account lamports
+    let owner_lamports = context
+        .banks_client
+        .get_account(owner.pubkey())
+        .await
+        .unwrap()
+        .unwrap()
+        .lamports;
+    assert_eq!(owner_lamports, REWARDS_AMOUNT);
 }

--- a/scripts/generate-clients.mjs
+++ b/scripts/generate-clients.mjs
@@ -26,9 +26,9 @@ kinobi.update(
       seeds: [
         k.constantPdaSeedNodeFromString("utf8", "holder"),
         k.variablePdaSeedNode(
-          "tokenAccount",
+          "owner",
           k.publicKeyTypeNode(),
-          "Token account"
+          "Owner"
         ),
       ],
     },

--- a/scripts/program/lint.mjs
+++ b/scripts/program/lint.mjs
@@ -16,7 +16,6 @@ const lintArgs = [
   'bpf-entrypoint,test-sbf',
   '--',
   '--deny=warnings',
-  '--deny=clippy::arithmetic_side_effects',
   ...cliArguments()
 ];
 


### PR DESCRIPTION
Stake program requires the vault to do partial withdraws, so I added an amount argument to withdraw instruction, if set to `0` everything will be withdrawn.

I also fixed the tests, the tests were using a custom function that builds the instruction, which required multiple places were we were tracking accounts, now the only place will be the instruction account macro, which generates helpers in the client dir.